### PR TITLE
Update to Webpack 2 syntax

### DIFF
--- a/tools/webpack/config.babel.js
+++ b/tools/webpack/config.babel.js
@@ -135,7 +135,7 @@ module.exports = {
         test: /\.jsx?$/,
         exclude: /node_modules/,
         loader: 'babel',
-        query: {
+        options: {
           cacheDirectory: isDev,
           babelrc: false,
           presets: [['es2015', { modules: false }], 'react', 'stage-0'],

--- a/tools/webpack/config.test.babel.js
+++ b/tools/webpack/config.test.babel.js
@@ -12,7 +12,7 @@ module.exports = {
         test: /\.jsx?$/,
         exclude: /node_modules/,
         loader: 'babel',
-        query: {
+        options: {
           cacheDirectory: true,
           babelrc: false,
           presets: [['es2015', { modules: false }], 'react', 'stage-0'],


### PR DESCRIPTION
Changed "query" to "options" — reflecting the new, preferred syntax in
Webpack 2.
