### PR TITLE
Remove specified OccurrenceOrderPlugin

### DIFF
--- a/tools/webpack/config.babel.js
+++ b/tools/webpack/config.babel.js
@@ -81,8 +81,7 @@ const getPlugins = () => {
         compress: { screw_ie8: true, warnings: false },
         output: { comments: false },
         sourceMap: false,
-      }),
-      new webpack.optimize.OccurrenceOrderPlugin(true)
+      })
     );
   }
 


### PR DESCRIPTION
Removed unnecessary OccurrenceOrderPlugin code from Webpack config —
it's now included with Webpack 2 by default.