### PR TITLE
Infrastructure configs are separated

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "es2015",
+    "react",
+    "stage-0"
+  ]
+}

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+# Browsers that we support
+
+last 2 versions
+not ie <= 8

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,42 @@
+{
+  "parser": "babel-eslint",
+  "extends": "airbnb",
+  "plugins": [
+    "react",
+    "jsx-a11y",
+    "import"
+  ],
+  "env": {
+    "browser": true,
+    "node": true,
+    "jest": true,
+    "es6": true
+  },
+  "rules": {
+    "global-require": 0,
+    "no-underscore-dangle": 0,
+    "no-console": 0,
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [
+          ".js",
+          ".jsx"
+        ]
+      }
+    ],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
+  },
+  "globals": {
+    "__CLIENT__": true,
+    "__SERVER__": true,
+    "__DISABLE_SSR__": true,
+    "__DEV__": true,
+    "webpackIsomorphicTools": true
+  }
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,15 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "string-quotes": "single",
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": [
+          "global",
+          "local"
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -108,48 +108,6 @@
       "command": "cat ./coverage/lcov.info | coveralls"
     }
   },
-  "eslintConfig": {
-    "parser": "babel-eslint",
-    "extends": "airbnb",
-    "plugins": [
-      "react",
-      "jsx-a11y",
-      "import"
-    ],
-    "env": {
-      "browser": true,
-      "node": true,
-      "jest": true,
-      "es6": true
-    },
-    "rules": {
-      "global-require": 0,
-      "no-underscore-dangle": 0,
-      "no-console": 0,
-      "react/jsx-filename-extension": [
-        1,
-        {
-          "extensions": [
-            ".js",
-            ".jsx"
-          ]
-        }
-      ],
-      "import/no-extraneous-dependencies": [
-        "error",
-        {
-          "devDependencies": true
-        }
-      ]
-    },
-    "globals": {
-      "__CLIENT__": true,
-      "__SERVER__": true,
-      "__DISABLE_SSR__": true,
-      "__DEV__": true,
-      "webpackIsomorphicTools": true
-    }
-  },
   "stylelint": {
     "extends": "stylelint-config-standard",
     "rules": {

--- a/package.json
+++ b/package.json
@@ -108,13 +108,6 @@
       "command": "cat ./coverage/lcov.info | coveralls"
     }
   },
-  "babel": {
-    "presets": [
-      "es2015",
-      "react",
-      "stage-0"
-    ]
-  },
   "eslintConfig": {
     "parser": "babel-eslint",
     "extends": "airbnb",

--- a/package.json
+++ b/package.json
@@ -108,21 +108,6 @@
       "command": "cat ./coverage/lcov.info | coveralls"
     }
   },
-  "stylelint": {
-    "extends": "stylelint-config-standard",
-    "rules": {
-      "string-quotes": "single",
-      "selector-pseudo-class-no-unknown": [
-        true,
-        {
-          "ignorePseudoClasses": [
-            "global",
-            "local"
-          ]
-        }
-      ]
-    }
-  },
   "dependencies": {
     "axios": "^0.16.1",
     "babel-polyfill": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       "command": "flow; test $? -eq 0 -o $? -eq 2"
     },
     "test": {
-      "command": "jest --coverage",
+      "command": "jest --coverage --config ./tools/jest/config.json",
       "env": {
         "NODE_ENV": "test"
       }
@@ -169,17 +169,6 @@
     "last 2 versions",
     "not ie <= 8"
   ],
-  "jest": {
-    "collectCoverageFrom": [
-      "src/containers/**/*.js",
-      "src/components/**/*.js",
-      "!src/**/__tests__"
-    ],
-    "moduleNameMapper": {
-      ".*\\.(css|scss|sass)$": "<rootDir>/tools/jest/styleMock.js",
-      ".*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tools/jest/assetMock.js"
-    }
-  },
   "dependencies": {
     "axios": "^0.16.1",
     "babel-polyfill": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -165,10 +165,6 @@
       ]
     }
   },
-  "browserslist": [
-    "last 2 versions",
-    "not ie <= 8"
-  ],
   "dependencies": {
     "axios": "^0.16.1",
     "babel-polyfill": "^6.23.0",

--- a/tools/jest/config.json
+++ b/tools/jest/config.json
@@ -1,0 +1,12 @@
+{
+  "rootDir": "../../",
+  "collectCoverageFrom": [
+    "src/containers/**/*.js",
+    "src/components/**/*.js",
+    "!src/**/__tests__"
+  ],
+  "moduleNameMapper": {
+    ".*\\.(css|scss|sass)$": "<rootDir>/tools/jest/styleMock.js",
+    ".*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tools/jest/assetMock.js"
+  }
+}


### PR DESCRIPTION
Hi! This starter kit is most enhanced between many others I've seen!  Many thanks for publishing it!

Concerning this PR, I've only moved all the configurations for build tools to separate files. It would improve the maintanability I think as well as simplify project overview. Also, it increases consistency since the starter consists of some other configuration files already. So no new configuration has been added excluding `rootDir` for Jest.