### PR TITLE
Added a solution to CRLF instead of LF error on windows in the troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,3 +521,19 @@ In the `./package.json` script:
 
 // ...
 ```
+
+* If you are on windows and encounter the following error: Expected linebreaks to be 'LF' but found 'CRLF' linebreak-style. The following rule must be added to package.json
+
+```
+"linebreak-style": 0
+```
+
+So it will look like:
+
+```
+// ...
+ "rules": {
+      "linebreak-style": 0,
+      "global-require": 0,
+// ...
+```


### PR DESCRIPTION
Using the starter on windows, an error bout line endings is displayed when trying to build the code.
This can be fixed by adding a new rule to the ESLint configuration on package.json.

This is an update to the troubleshooting section to show which rule should be added and where, so window users can read about this issue in advance.