### PR TITLE
Remove lodash from vendor bundle

### DIFF
--- a/tools/webpack/config.babel.js
+++ b/tools/webpack/config.babel.js
@@ -36,8 +36,7 @@ const vendor = [
   'react-router-redux',
   'react-helmet',
   'axios',
-  'redbox-react',
-  'lodash'
+  'redbox-react'
 ];
 
 // Setting the plugins for development/prodcution


### PR DESCRIPTION
We don't need unused lodash package in vendor bundle, so after this we reduce the bundle size.

![image](https://user-images.githubusercontent.com/5165362/34864030-6686a45a-f783-11e7-9b98-3c0856fbc404.png)

Or did I miss something here? :)