### PR TITLE
Remove lodash.min package from bundle

### DIFF
--- a/src/config/prod.js
+++ b/src/config/prod.js
@@ -1,7 +1,7 @@
-const _ = require('lodash/fp');
+const _merge = require('lodash/fp/merge');
 
 const defaultConfig = require('./default');
 
-module.exports = _.merge(defaultConfig, {
+module.exports = _merge(defaultConfig, {
   // Over write default settings here...
 });


### PR DESCRIPTION
Alright, I found the reason related to the second problem mentioned in this issue https://github.com/wellyshen/react-cool-starter/issues/141#issuecomment-357284282 and fixed it.
The main bundle reduced size from 134kb to 65.1kb.

![screenshot_21](https://user-images.githubusercontent.com/5165362/34907348-4c53b026-f88e-11e7-8a4f-c7b6d05cf530.png)

