### PR TITLE
Fix bundled assets inserts

### DIFF
--- a/src/helpers/renderHtml.js
+++ b/src/helpers/renderHtml.js
@@ -32,14 +32,16 @@ export default (
         ${head.link.toString()}
 
         <!-- Insert bundled styles into <link> tag -->
-        ${Object.keys(envAssets).map(
-          key =>
-            envAssets[key].css
-              ? `<link href="${
-                  envAssets[key].css
-                }" media="screen, projection" rel="stylesheet" type="text/css">`
-              : ''
-        )}
+        ${Object.keys(envAssets)
+          .map(
+            key =>
+              envAssets[key].css
+                ? `<link href="${
+                    envAssets[key].css
+                  }" media="screen, projection" rel="stylesheet" type="text/css">`
+                : ''
+          )
+          .join('')}
 
       </head>
       <body>
@@ -59,7 +61,8 @@ export default (
         <!-- Insert bundled scripts into <script> tag -->
         ${Object.keys(envAssets)
           .reverse() // Reverse scripts to get correct ordering
-          .map(key => `<script src="${envAssets[key].js}"></script>`)}
+          .map(key => `<script src="${envAssets[key].js}"></script>`)
+          .join('')}
 
         ${head.script.toString()}
       </body>


### PR DESCRIPTION
The default behaviour of JS toString on an array is to join with separator comma (,). This causes comma's to show up at the top and bottom of the page in production mode from the bundled envAsset includes.

**Fix**: join with empty string.

![screen shot 2018-03-15 at 21 42 38](https://user-images.githubusercontent.com/9120530/37490674-9bc2dd70-289b-11e8-8782-3bfccf9f6792.png)
