### PR TITLE
Fix disconnect between client and server html

### DIFF
--- a/public/loadable-assets.json
+++ b/public/loadable-assets.json
@@ -1,18 +1,4 @@
 {
-  "./home": [
-    {
-      "id": "./src/reducers/home.js",
-      "name": "./src/reducers/home.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/reducers/home.js",
-      "name": "./src/reducers/home.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
   "undefined": [
     {
       "id": 0,
@@ -21,55 +7,55 @@
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?b1bb",
+      "id": "?1f82",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?7fd0",
+      "id": "?23b0",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?906e",
+      "id": "?4097",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?5af7",
+      "id": "?4fb3",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?a396",
+      "id": "?7768",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?d464",
+      "id": "?9b69",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?b13f",
+      "id": "?ae88",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?cd3e",
+      "id": "?bb4d",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?f390",
+      "id": "?f89f",
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
@@ -81,154 +67,112 @@
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?b1bb",
+      "id": "?1f82",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?7fd0",
+      "id": "?23b0",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?906e",
+      "id": "?4097",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?5af7",
+      "id": "?4fb3",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?a396",
+      "id": "?7768",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?d464",
+      "id": "?9b69",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?b13f",
+      "id": "?ae88",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?cd3e",
+      "id": "?bb4d",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?f390",
+      "id": "?f89f",
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./../webpack/buildin/module.js": [
+  "@babel/runtime/helpers/esm/assertThisInitialized": [
     {
-      "id": "./node_modules/webpack/buildin/module.js",
-      "name": "./node_modules/webpack/buildin/module.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/webpack/buildin/module.js",
-      "name": "./node_modules/webpack/buildin/module.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "querystring": [
+  "@babel/runtime/helpers/esm/extends": [
     {
-      "id": "./node_modules/querystring-es3/index.js",
-      "name": "./node_modules/querystring-es3/index.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/extends.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/extends.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/querystring-es3/index.js",
-      "name": "./node_modules/querystring-es3/index.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/extends.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/extends.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./decode": [
+  "@babel/runtime/helpers/esm/inheritsLoose": [
     {
-      "id": "./node_modules/querystring-es3/decode.js",
-      "name": "./node_modules/querystring-es3/decode.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/querystring-es3/decode.js",
-      "name": "./node_modules/querystring-es3/decode.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./encode": [
+  "@babel/runtime/helpers/esm/objectWithoutPropertiesLoose": [
     {
-      "id": "./node_modules/querystring-es3/encode.js",
-      "name": "./node_modules/querystring-es3/encode.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/querystring-es3/encode.js",
-      "name": "./node_modules/querystring-es3/encode.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "strip-ansi": [
-    {
-      "id": "./node_modules/strip-ansi/index.js",
-      "name": "./node_modules/strip-ansi/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/strip-ansi/index.js",
-      "name": "./node_modules/strip-ansi/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "ansi-regex": [
-    {
-      "id": "./node_modules/ansi-regex/index.js",
-      "name": "./node_modules/ansi-regex/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/ansi-regex/index.js",
-      "name": "./node_modules/ansi-regex/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./client-overlay": [
-    {
-      "id": "./node_modules/webpack-hot-middleware/client-overlay.js",
-      "name": "./node_modules/webpack-hot-middleware/client-overlay.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/webpack-hot-middleware/client-overlay.js",
-      "name": "./node_modules/webpack-hot-middleware/client-overlay.js",
+      "id": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -247,704 +191,1848 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "html-entities": [
+  "ansi-regex": [
     {
-      "id": "./node_modules/html-entities/index.js",
-      "name": "./node_modules/html-entities/index.js",
+      "id": "./node_modules/ansi-regex/index.js",
+      "name": "./node_modules/ansi-regex/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/html-entities/index.js",
-      "name": "./node_modules/html-entities/index.js",
+      "id": "./node_modules/ansi-regex/index.js",
+      "name": "./node_modules/ansi-regex/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./lib/xml-entities.js": [
+  "axios": [
     {
-      "id": "./node_modules/html-entities/lib/xml-entities.js",
-      "name": "./node_modules/html-entities/lib/xml-entities.js",
+      "id": "./node_modules/axios/index.js",
+      "name": "./node_modules/axios/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/html-entities/lib/xml-entities.js",
-      "name": "./node_modules/html-entities/lib/xml-entities.js",
+      "id": "./node_modules/axios/index.js",
+      "name": "./node_modules/axios/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./lib/html4-entities.js": [
+  "./adapters/xhr": [
     {
-      "id": "./node_modules/html-entities/lib/html4-entities.js",
-      "name": "./node_modules/html-entities/lib/html4-entities.js",
+      "id": "./node_modules/axios/lib/adapters/xhr.js",
+      "name": "./node_modules/axios/lib/adapters/xhr.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/html-entities/lib/html4-entities.js",
-      "name": "./node_modules/html-entities/lib/html4-entities.js",
+      "id": "./node_modules/axios/lib/adapters/xhr.js",
+      "name": "./node_modules/axios/lib/adapters/xhr.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./lib/html5-entities.js": [
+  "./lib/axios": [
     {
-      "id": "./node_modules/html-entities/lib/html5-entities.js",
-      "name": "./node_modules/html-entities/lib/html5-entities.js",
+      "id": "./node_modules/axios/lib/axios.js",
+      "name": "./node_modules/axios/lib/axios.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/html-entities/lib/html5-entities.js",
-      "name": "./node_modules/html-entities/lib/html5-entities.js",
+      "id": "./node_modules/axios/lib/axios.js",
+      "name": "./node_modules/axios/lib/axios.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./process-update": [
+  "./cancel/Cancel": [
     {
-      "id": "./node_modules/webpack-hot-middleware/process-update.js",
-      "name": "./node_modules/webpack-hot-middleware/process-update.js",
+      "id": "./node_modules/axios/lib/cancel/Cancel.js",
+      "name": "./node_modules/axios/lib/cancel/Cancel.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/webpack-hot-middleware/process-update.js",
-      "name": "./node_modules/webpack-hot-middleware/process-update.js",
+      "id": "./node_modules/axios/lib/cancel/Cancel.js",
+      "name": "./node_modules/axios/lib/cancel/Cancel.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./src/client.js": [
+  "./cancel/CancelToken": [
     {
-      "id": "./src/client.js",
-      "name": "./src/client.js",
+      "id": "./node_modules/axios/lib/cancel/CancelToken.js",
+      "name": "./node_modules/axios/lib/cancel/CancelToken.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/client.js",
-      "name": "./src/client.js",
+      "id": "./node_modules/axios/lib/cancel/CancelToken.js",
+      "name": "./node_modules/axios/lib/cancel/CancelToken.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./../node_modules/webpack/buildin/harmony-module.js": [
+  "./cancel/isCancel": [
     {
-      "id": "./node_modules/webpack/buildin/harmony-module.js",
-      "name": "./node_modules/webpack/buildin/harmony-module.js",
+      "id": "./node_modules/axios/lib/cancel/isCancel.js",
+      "name": "./node_modules/axios/lib/cancel/isCancel.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/webpack/buildin/harmony-module.js",
-      "name": "./node_modules/webpack/buildin/harmony-module.js",
+      "id": "./node_modules/axios/lib/cancel/isCancel.js",
+      "name": "./node_modules/axios/lib/cancel/isCancel.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "react-hot-loader": [
+  "./core/Axios": [
     {
-      "id": "./node_modules/react-hot-loader/index.js",
-      "name": "./node_modules/react-hot-loader/index.js",
+      "id": "./node_modules/axios/lib/core/Axios.js",
+      "name": "./node_modules/axios/lib/core/Axios.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-hot-loader/index.js",
-      "name": "./node_modules/react-hot-loader/index.js",
+      "id": "./node_modules/axios/lib/core/Axios.js",
+      "name": "./node_modules/axios/lib/core/Axios.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./dist/react-hot-loader.production.min.js": [
+  "./InterceptorManager": [
     {
-      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
-      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "id": "./node_modules/axios/lib/core/InterceptorManager.js",
+      "name": "./node_modules/axios/lib/core/InterceptorManager.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
-      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "id": "./node_modules/axios/lib/core/InterceptorManager.js",
+      "name": "./node_modules/axios/lib/core/InterceptorManager.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "react": [
+  "../core/createError": [
     {
-      "id": "./node_modules/react/index.js",
-      "name": "./node_modules/react/index.js",
+      "id": "./node_modules/axios/lib/core/createError.js",
+      "name": "./node_modules/axios/lib/core/createError.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react/index.js",
-      "name": "./node_modules/react/index.js",
+      "id": "./node_modules/axios/lib/core/createError.js",
+      "name": "./node_modules/axios/lib/core/createError.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./cjs/react.development.js": [
+  "./dispatchRequest": [
     {
-      "id": "./node_modules/react/cjs/react.development.js",
-      "name": "./node_modules/react/cjs/react.development.js",
+      "id": "./node_modules/axios/lib/core/dispatchRequest.js",
+      "name": "./node_modules/axios/lib/core/dispatchRequest.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react/cjs/react.development.js",
-      "name": "./node_modules/react/cjs/react.development.js",
+      "id": "./node_modules/axios/lib/core/dispatchRequest.js",
+      "name": "./node_modules/axios/lib/core/dispatchRequest.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "object-assign": [
+  "./enhanceError": [
     {
-      "id": "./node_modules/object-assign/index.js",
-      "name": "./node_modules/object-assign/index.js",
+      "id": "./node_modules/axios/lib/core/enhanceError.js",
+      "name": "./node_modules/axios/lib/core/enhanceError.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/object-assign/index.js",
-      "name": "./node_modules/object-assign/index.js",
+      "id": "./node_modules/axios/lib/core/enhanceError.js",
+      "name": "./node_modules/axios/lib/core/enhanceError.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "prop-types/checkPropTypes": [
+  "./../core/settle": [
     {
-      "id": "./node_modules/react/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react/node_modules/prop-types/checkPropTypes.js",
+      "id": "./node_modules/axios/lib/core/settle.js",
+      "name": "./node_modules/axios/lib/core/settle.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-dom/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-dom/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-dom/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-dom/node_modules/prop-types/checkPropTypes.js",
+      "id": "./node_modules/axios/lib/core/settle.js",
+      "name": "./node_modules/axios/lib/core/settle.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./lib/ReactPropTypesSecret": [
+  "./transformData": [
     {
-      "id": "./node_modules/react/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react/node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "id": "./node_modules/axios/lib/core/transformData.js",
+      "name": "./node_modules/axios/lib/core/transformData.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "id": "./node_modules/axios/lib/core/transformData.js",
+      "name": "./node_modules/axios/lib/core/transformData.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./dist/react-hot-loader.development.js": [
+  "./defaults": [
     {
-      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
-      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "id": "./node_modules/axios/lib/defaults.js",
+      "name": "./node_modules/axios/lib/defaults.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
-      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "id": "./node_modules/axios/lib/defaults.js",
+      "name": "./node_modules/axios/lib/defaults.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "shallowequal": [
+  "./helpers/bind": [
     {
-      "id": "./node_modules/shallowequal/index.js",
-      "name": "./node_modules/shallowequal/index.js",
+      "id": "./node_modules/axios/lib/helpers/bind.js",
+      "name": "./node_modules/axios/lib/helpers/bind.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/shallowequal/index.js",
-      "name": "./node_modules/shallowequal/index.js",
+      "id": "./node_modules/axios/lib/helpers/bind.js",
+      "name": "./node_modules/axios/lib/helpers/bind.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "react-dom": [
+  "./../helpers/btoa": [
     {
-      "id": "./node_modules/react-dom/index.js",
-      "name": "./node_modules/react-dom/index.js",
+      "id": "./node_modules/axios/lib/helpers/btoa.js",
+      "name": "./node_modules/axios/lib/helpers/btoa.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-dom/index.js",
-      "name": "./node_modules/react-dom/index.js",
+      "id": "./node_modules/axios/lib/helpers/btoa.js",
+      "name": "./node_modules/axios/lib/helpers/btoa.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./cjs/react-dom.development.js": [
+  "./../helpers/buildURL": [
     {
-      "id": "./node_modules/react-dom/cjs/react-dom.development.js",
-      "name": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "id": "./node_modules/axios/lib/helpers/buildURL.js",
+      "name": "./node_modules/axios/lib/helpers/buildURL.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-dom/cjs/react-dom.development.js",
-      "name": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "id": "./node_modules/axios/lib/helpers/buildURL.js",
+      "name": "./node_modules/axios/lib/helpers/buildURL.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "scheduler": [
+  "./../helpers/combineURLs": [
     {
-      "id": "./node_modules/scheduler/index.js",
-      "name": "./node_modules/scheduler/index.js",
+      "id": "./node_modules/axios/lib/helpers/combineURLs.js",
+      "name": "./node_modules/axios/lib/helpers/combineURLs.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/scheduler/index.js",
-      "name": "./node_modules/scheduler/index.js",
+      "id": "./node_modules/axios/lib/helpers/combineURLs.js",
+      "name": "./node_modules/axios/lib/helpers/combineURLs.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./cjs/scheduler.development.js": [
+  "./../helpers/cookies": [
     {
-      "id": "./node_modules/scheduler/cjs/scheduler.development.js",
-      "name": "./node_modules/scheduler/cjs/scheduler.development.js",
+      "id": "./node_modules/axios/lib/helpers/cookies.js",
+      "name": "./node_modules/axios/lib/helpers/cookies.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/scheduler/cjs/scheduler.development.js",
-      "name": "./node_modules/scheduler/cjs/scheduler.development.js",
+      "id": "./node_modules/axios/lib/helpers/cookies.js",
+      "name": "./node_modules/axios/lib/helpers/cookies.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./../../webpack/buildin/global.js": [
+  "./../helpers/isAbsoluteURL": [
     {
-      "id": "./node_modules/webpack/buildin/global.js",
-      "name": "./node_modules/webpack/buildin/global.js",
+      "id": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
+      "name": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/webpack/buildin/global.js",
-      "name": "./node_modules/webpack/buildin/global.js",
+      "id": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
+      "name": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "scheduler/tracing": [
+  "./../helpers/isURLSameOrigin": [
     {
-      "id": "./node_modules/scheduler/tracing.js",
-      "name": "./node_modules/scheduler/tracing.js",
+      "id": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
+      "name": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/scheduler/tracing.js",
-      "name": "./node_modules/scheduler/tracing.js",
+      "id": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
+      "name": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./cjs/scheduler-tracing.development.js": [
+  "./helpers/normalizeHeaderName": [
     {
-      "id": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
-      "name": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
+      "id": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
+      "name": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
-      "name": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
+      "id": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
+      "name": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "prop-types": [
+  "./../helpers/parseHeaders": [
     {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/index.js",
+      "id": "./node_modules/axios/lib/helpers/parseHeaders.js",
+      "name": "./node_modules/axios/lib/helpers/parseHeaders.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-redux/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/prop-types/index.js",
-      "name": "./node_modules/prop-types/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/prop-types/index.js",
-      "name": "./node_modules/prop-types/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/index.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/index.js",
+      "id": "./node_modules/axios/lib/helpers/parseHeaders.js",
+      "name": "./node_modules/axios/lib/helpers/parseHeaders.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./factoryWithTypeCheckers": [
+  "./helpers/spread": [
     {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/factoryWithTypeCheckers.js",
+      "id": "./node_modules/axios/lib/helpers/spread.js",
+      "name": "./node_modules/axios/lib/helpers/spread.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-redux/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/factoryWithTypeCheckers.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/factoryWithTypeCheckers.js",
+      "id": "./node_modules/axios/lib/helpers/spread.js",
+      "name": "./node_modules/axios/lib/helpers/spread.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./checkPropTypes": [
+  "./utils": [
     {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/checkPropTypes.js",
+      "id": "./node_modules/axios/lib/utils.js",
+      "name": "./node_modules/axios/lib/utils.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-redux/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/prop-types/checkPropTypes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-hot-loader/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-hot-loader/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-redux/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/prop-types/checkPropTypes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-router/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-router-dom/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-loadable/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-loadable/node_modules/prop-types/checkPropTypes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-helmet/node_modules/prop-types/checkPropTypes.js",
-      "name": "./node_modules/react-helmet/node_modules/prop-types/checkPropTypes.js",
+      "id": "./node_modules/axios/lib/utils.js",
+      "name": "./node_modules/axios/lib/utils.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "react-lifecycles-compat": [
+  "./ConnectedRouter": [
     {
-      "id": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
-      "name": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "id": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
+      "name": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
-      "name": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "id": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
+      "name": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./actions": [
+    {
+      "id": "./node_modules/connected-react-router/esm/actions.js",
+      "name": "./node_modules/connected-react-router/esm/actions.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/actions/index.js",
+      "name": "./src/actions/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/actions.js",
+      "name": "./node_modules/connected-react-router/esm/actions.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/actions/index.js",
+      "name": "./src/actions/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "connected-react-router": [
+    {
+      "id": "./node_modules/connected-react-router/esm/index.js",
+      "name": "./node_modules/connected-react-router/esm/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/index.js",
+      "name": "./node_modules/connected-react-router/esm/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./middleware": [
+    {
+      "id": "./node_modules/connected-react-router/esm/middleware.js",
+      "name": "./node_modules/connected-react-router/esm/middleware.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/middleware.js",
+      "name": "./node_modules/connected-react-router/esm/middleware.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./reducer": [
+    {
+      "id": "./node_modules/connected-react-router/esm/reducer.js",
+      "name": "./node_modules/connected-react-router/esm/reducer.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/reducer.js",
+      "name": "./node_modules/connected-react-router/esm/reducer.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./selectors": [
+    {
+      "id": "./node_modules/connected-react-router/esm/selectors.js",
+      "name": "./node_modules/connected-react-router/esm/selectors.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/selectors.js",
+      "name": "./node_modules/connected-react-router/esm/selectors.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./getIn": [
+    {
+      "id": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
+      "name": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
+      "name": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./structure/plain": [
+    {
+      "id": "./node_modules/connected-react-router/esm/structure/plain/index.js",
+      "name": "./node_modules/connected-react-router/esm/structure/plain/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/structure/plain/index.js",
+      "name": "./node_modules/connected-react-router/esm/structure/plain/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_a-function": [
+    {
+      "id": "./node_modules/core-js/modules/_a-function.js",
+      "name": "./node_modules/core-js/modules/_a-function.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_a-function.js",
+      "name": "./node_modules/core-js/modules/_a-function.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_add-to-unscopables": [
+    {
+      "id": "./node_modules/core-js/modules/_add-to-unscopables.js",
+      "name": "./node_modules/core-js/modules/_add-to-unscopables.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_add-to-unscopables.js",
+      "name": "./node_modules/core-js/modules/_add-to-unscopables.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_advance-string-index": [
+    {
+      "id": "./node_modules/core-js/modules/_advance-string-index.js",
+      "name": "./node_modules/core-js/modules/_advance-string-index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_advance-string-index.js",
+      "name": "./node_modules/core-js/modules/_advance-string-index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_an-instance": [
+    {
+      "id": "./node_modules/core-js/modules/_an-instance.js",
+      "name": "./node_modules/core-js/modules/_an-instance.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_an-instance.js",
+      "name": "./node_modules/core-js/modules/_an-instance.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_an-object": [
+    {
+      "id": "./node_modules/core-js/modules/_an-object.js",
+      "name": "./node_modules/core-js/modules/_an-object.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_an-object.js",
+      "name": "./node_modules/core-js/modules/_an-object.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_array-includes": [
+    {
+      "id": "./node_modules/core-js/modules/_array-includes.js",
+      "name": "./node_modules/core-js/modules/_array-includes.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_array-includes.js",
+      "name": "./node_modules/core-js/modules/_array-includes.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_classof": [
+    {
+      "id": "./node_modules/core-js/modules/_classof.js",
+      "name": "./node_modules/core-js/modules/_classof.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_classof.js",
+      "name": "./node_modules/core-js/modules/_classof.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_cof": [
+    {
+      "id": "./node_modules/core-js/modules/_cof.js",
+      "name": "./node_modules/core-js/modules/_cof.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_cof.js",
+      "name": "./node_modules/core-js/modules/_cof.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_core": [
+    {
+      "id": "./node_modules/core-js/modules/_core.js",
+      "name": "./node_modules/core-js/modules/_core.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_core.js",
+      "name": "./node_modules/core-js/modules/_core.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_ctx": [
+    {
+      "id": "./node_modules/core-js/modules/_ctx.js",
+      "name": "./node_modules/core-js/modules/_ctx.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_ctx.js",
+      "name": "./node_modules/core-js/modules/_ctx.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_defined": [
+    {
+      "id": "./node_modules/core-js/modules/_defined.js",
+      "name": "./node_modules/core-js/modules/_defined.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_defined.js",
+      "name": "./node_modules/core-js/modules/_defined.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_descriptors": [
+    {
+      "id": "./node_modules/core-js/modules/_descriptors.js",
+      "name": "./node_modules/core-js/modules/_descriptors.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_descriptors.js",
+      "name": "./node_modules/core-js/modules/_descriptors.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_dom-create": [
+    {
+      "id": "./node_modules/core-js/modules/_dom-create.js",
+      "name": "./node_modules/core-js/modules/_dom-create.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_dom-create.js",
+      "name": "./node_modules/core-js/modules/_dom-create.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_enum-bug-keys": [
+    {
+      "id": "./node_modules/core-js/modules/_enum-bug-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-bug-keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_enum-bug-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-bug-keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_enum-keys": [
+    {
+      "id": "./node_modules/core-js/modules/_enum-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_enum-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_export": [
+    {
+      "id": "./node_modules/core-js/modules/_export.js",
+      "name": "./node_modules/core-js/modules/_export.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_export.js",
+      "name": "./node_modules/core-js/modules/_export.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_fails": [
+    {
+      "id": "./node_modules/core-js/modules/_fails.js",
+      "name": "./node_modules/core-js/modules/_fails.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_fails.js",
+      "name": "./node_modules/core-js/modules/_fails.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_fix-re-wks": [
+    {
+      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_flags": [
+    {
+      "id": "./node_modules/core-js/modules/_flags.js",
+      "name": "./node_modules/core-js/modules/_flags.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_flags.js",
+      "name": "./node_modules/core-js/modules/_flags.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_for-of": [
+    {
+      "id": "./node_modules/core-js/modules/_for-of.js",
+      "name": "./node_modules/core-js/modules/_for-of.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_for-of.js",
+      "name": "./node_modules/core-js/modules/_for-of.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_function-to-string": [
+    {
+      "id": "./node_modules/core-js/modules/_function-to-string.js",
+      "name": "./node_modules/core-js/modules/_function-to-string.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_function-to-string.js",
+      "name": "./node_modules/core-js/modules/_function-to-string.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_global": [
+    {
+      "id": "./node_modules/core-js/modules/_global.js",
+      "name": "./node_modules/core-js/modules/_global.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_global.js",
+      "name": "./node_modules/core-js/modules/_global.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_has": [
+    {
+      "id": "./node_modules/core-js/modules/_has.js",
+      "name": "./node_modules/core-js/modules/_has.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_has.js",
+      "name": "./node_modules/core-js/modules/_has.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_hide": [
+    {
+      "id": "./node_modules/core-js/modules/_hide.js",
+      "name": "./node_modules/core-js/modules/_hide.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_hide.js",
+      "name": "./node_modules/core-js/modules/_hide.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_html": [
+    {
+      "id": "./node_modules/core-js/modules/_html.js",
+      "name": "./node_modules/core-js/modules/_html.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_html.js",
+      "name": "./node_modules/core-js/modules/_html.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_ie8-dom-define": [
+    {
+      "id": "./node_modules/core-js/modules/_ie8-dom-define.js",
+      "name": "./node_modules/core-js/modules/_ie8-dom-define.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_ie8-dom-define.js",
+      "name": "./node_modules/core-js/modules/_ie8-dom-define.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_invoke": [
+    {
+      "id": "./node_modules/core-js/modules/_invoke.js",
+      "name": "./node_modules/core-js/modules/_invoke.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_invoke.js",
+      "name": "./node_modules/core-js/modules/_invoke.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_iobject": [
+    {
+      "id": "./node_modules/core-js/modules/_iobject.js",
+      "name": "./node_modules/core-js/modules/_iobject.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iobject.js",
+      "name": "./node_modules/core-js/modules/_iobject.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_is-array-iter": [
+    {
+      "id": "./node_modules/core-js/modules/_is-array-iter.js",
+      "name": "./node_modules/core-js/modules/_is-array-iter.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_is-array-iter.js",
+      "name": "./node_modules/core-js/modules/_is-array-iter.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_is-array": [
+    {
+      "id": "./node_modules/core-js/modules/_is-array.js",
+      "name": "./node_modules/core-js/modules/_is-array.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_is-array.js",
+      "name": "./node_modules/core-js/modules/_is-array.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_is-object": [
+    {
+      "id": "./node_modules/core-js/modules/_is-object.js",
+      "name": "./node_modules/core-js/modules/_is-object.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_is-object.js",
+      "name": "./node_modules/core-js/modules/_is-object.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_iter-call": [
+    {
+      "id": "./node_modules/core-js/modules/_iter-call.js",
+      "name": "./node_modules/core-js/modules/_iter-call.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-call.js",
+      "name": "./node_modules/core-js/modules/_iter-call.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_iter-create": [
+    {
+      "id": "./node_modules/core-js/modules/_iter-create.js",
+      "name": "./node_modules/core-js/modules/_iter-create.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-create.js",
+      "name": "./node_modules/core-js/modules/_iter-create.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_iter-define": [
+    {
+      "id": "./node_modules/core-js/modules/_iter-define.js",
+      "name": "./node_modules/core-js/modules/_iter-define.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-define.js",
+      "name": "./node_modules/core-js/modules/_iter-define.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_iter-detect": [
+    {
+      "id": "./node_modules/core-js/modules/_iter-detect.js",
+      "name": "./node_modules/core-js/modules/_iter-detect.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-detect.js",
+      "name": "./node_modules/core-js/modules/_iter-detect.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_iter-step": [
+    {
+      "id": "./node_modules/core-js/modules/_iter-step.js",
+      "name": "./node_modules/core-js/modules/_iter-step.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-step.js",
+      "name": "./node_modules/core-js/modules/_iter-step.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_iterators": [
+    {
+      "id": "./node_modules/core-js/modules/_iterators.js",
+      "name": "./node_modules/core-js/modules/_iterators.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iterators.js",
+      "name": "./node_modules/core-js/modules/_iterators.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_library": [
+    {
+      "id": "./node_modules/core-js/modules/_library.js",
+      "name": "./node_modules/core-js/modules/_library.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_library.js",
+      "name": "./node_modules/core-js/modules/_library.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_meta": [
+    {
+      "id": "./node_modules/core-js/modules/_meta.js",
+      "name": "./node_modules/core-js/modules/_meta.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_meta.js",
+      "name": "./node_modules/core-js/modules/_meta.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_microtask": [
+    {
+      "id": "./node_modules/core-js/modules/_microtask.js",
+      "name": "./node_modules/core-js/modules/_microtask.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_microtask.js",
+      "name": "./node_modules/core-js/modules/_microtask.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_new-promise-capability": [
+    {
+      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-create": [
+    {
+      "id": "./node_modules/core-js/modules/_object-create.js",
+      "name": "./node_modules/core-js/modules/_object-create.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-create.js",
+      "name": "./node_modules/core-js/modules/_object-create.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-dp": [
+    {
+      "id": "./node_modules/core-js/modules/_object-dp.js",
+      "name": "./node_modules/core-js/modules/_object-dp.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-dp.js",
+      "name": "./node_modules/core-js/modules/_object-dp.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-dps": [
+    {
+      "id": "./node_modules/core-js/modules/_object-dps.js",
+      "name": "./node_modules/core-js/modules/_object-dps.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-dps.js",
+      "name": "./node_modules/core-js/modules/_object-dps.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-gopd": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gopd.js",
+      "name": "./node_modules/core-js/modules/_object-gopd.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopd.js",
+      "name": "./node_modules/core-js/modules/_object-gopd.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-gopn-ext": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-gopn": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn.js",
+      "name": "./node_modules/core-js/modules/_object-gopn.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn.js",
+      "name": "./node_modules/core-js/modules/_object-gopn.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-gops": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gops.js",
+      "name": "./node_modules/core-js/modules/_object-gops.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gops.js",
+      "name": "./node_modules/core-js/modules/_object-gops.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-gpo": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gpo.js",
+      "name": "./node_modules/core-js/modules/_object-gpo.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gpo.js",
+      "name": "./node_modules/core-js/modules/_object-gpo.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-keys-internal": [
+    {
+      "id": "./node_modules/core-js/modules/_object-keys-internal.js",
+      "name": "./node_modules/core-js/modules/_object-keys-internal.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-keys-internal.js",
+      "name": "./node_modules/core-js/modules/_object-keys-internal.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-keys": [
+    {
+      "id": "./node_modules/core-js/modules/_object-keys.js",
+      "name": "./node_modules/core-js/modules/_object-keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-keys.js",
+      "name": "./node_modules/core-js/modules/_object-keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-pie": [
+    {
+      "id": "./node_modules/core-js/modules/_object-pie.js",
+      "name": "./node_modules/core-js/modules/_object-pie.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-pie.js",
+      "name": "./node_modules/core-js/modules/_object-pie.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_object-sap": [
+    {
+      "id": "./node_modules/core-js/modules/_object-sap.js",
+      "name": "./node_modules/core-js/modules/_object-sap.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-sap.js",
+      "name": "./node_modules/core-js/modules/_object-sap.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_perform": [
+    {
+      "id": "./node_modules/core-js/modules/_perform.js",
+      "name": "./node_modules/core-js/modules/_perform.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_perform.js",
+      "name": "./node_modules/core-js/modules/_perform.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_promise-resolve": [
+    {
+      "id": "./node_modules/core-js/modules/_promise-resolve.js",
+      "name": "./node_modules/core-js/modules/_promise-resolve.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_promise-resolve.js",
+      "name": "./node_modules/core-js/modules/_promise-resolve.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_property-desc": [
+    {
+      "id": "./node_modules/core-js/modules/_property-desc.js",
+      "name": "./node_modules/core-js/modules/_property-desc.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_property-desc.js",
+      "name": "./node_modules/core-js/modules/_property-desc.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_redefine-all": [
+    {
+      "id": "./node_modules/core-js/modules/_redefine-all.js",
+      "name": "./node_modules/core-js/modules/_redefine-all.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_redefine-all.js",
+      "name": "./node_modules/core-js/modules/_redefine-all.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_redefine": [
+    {
+      "id": "./node_modules/core-js/modules/_redefine.js",
+      "name": "./node_modules/core-js/modules/_redefine.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_redefine.js",
+      "name": "./node_modules/core-js/modules/_redefine.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_regexp-exec-abstract": [
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_regexp-exec": [
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_set-proto": [
+    {
+      "id": "./node_modules/core-js/modules/_set-proto.js",
+      "name": "./node_modules/core-js/modules/_set-proto.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-proto.js",
+      "name": "./node_modules/core-js/modules/_set-proto.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_set-species": [
+    {
+      "id": "./node_modules/core-js/modules/_set-species.js",
+      "name": "./node_modules/core-js/modules/_set-species.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-species.js",
+      "name": "./node_modules/core-js/modules/_set-species.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_set-to-string-tag": [
+    {
+      "id": "./node_modules/core-js/modules/_set-to-string-tag.js",
+      "name": "./node_modules/core-js/modules/_set-to-string-tag.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-to-string-tag.js",
+      "name": "./node_modules/core-js/modules/_set-to-string-tag.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_shared-key": [
+    {
+      "id": "./node_modules/core-js/modules/_shared-key.js",
+      "name": "./node_modules/core-js/modules/_shared-key.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_shared-key.js",
+      "name": "./node_modules/core-js/modules/_shared-key.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_shared": [
+    {
+      "id": "./node_modules/core-js/modules/_shared.js",
+      "name": "./node_modules/core-js/modules/_shared.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_shared.js",
+      "name": "./node_modules/core-js/modules/_shared.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_species-constructor": [
+    {
+      "id": "./node_modules/core-js/modules/_species-constructor.js",
+      "name": "./node_modules/core-js/modules/_species-constructor.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_species-constructor.js",
+      "name": "./node_modules/core-js/modules/_species-constructor.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_string-at": [
+    {
+      "id": "./node_modules/core-js/modules/_string-at.js",
+      "name": "./node_modules/core-js/modules/_string-at.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_string-at.js",
+      "name": "./node_modules/core-js/modules/_string-at.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_task": [
+    {
+      "id": "./node_modules/core-js/modules/_task.js",
+      "name": "./node_modules/core-js/modules/_task.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_task.js",
+      "name": "./node_modules/core-js/modules/_task.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_to-absolute-index": [
+    {
+      "id": "./node_modules/core-js/modules/_to-absolute-index.js",
+      "name": "./node_modules/core-js/modules/_to-absolute-index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-absolute-index.js",
+      "name": "./node_modules/core-js/modules/_to-absolute-index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_to-integer": [
+    {
+      "id": "./node_modules/core-js/modules/_to-integer.js",
+      "name": "./node_modules/core-js/modules/_to-integer.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-integer.js",
+      "name": "./node_modules/core-js/modules/_to-integer.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_to-iobject": [
+    {
+      "id": "./node_modules/core-js/modules/_to-iobject.js",
+      "name": "./node_modules/core-js/modules/_to-iobject.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-iobject.js",
+      "name": "./node_modules/core-js/modules/_to-iobject.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_to-length": [
+    {
+      "id": "./node_modules/core-js/modules/_to-length.js",
+      "name": "./node_modules/core-js/modules/_to-length.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-length.js",
+      "name": "./node_modules/core-js/modules/_to-length.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_to-object": [
+    {
+      "id": "./node_modules/core-js/modules/_to-object.js",
+      "name": "./node_modules/core-js/modules/_to-object.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-object.js",
+      "name": "./node_modules/core-js/modules/_to-object.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_to-primitive": [
+    {
+      "id": "./node_modules/core-js/modules/_to-primitive.js",
+      "name": "./node_modules/core-js/modules/_to-primitive.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-primitive.js",
+      "name": "./node_modules/core-js/modules/_to-primitive.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_uid": [
+    {
+      "id": "./node_modules/core-js/modules/_uid.js",
+      "name": "./node_modules/core-js/modules/_uid.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_uid.js",
+      "name": "./node_modules/core-js/modules/_uid.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_user-agent": [
+    {
+      "id": "./node_modules/core-js/modules/_user-agent.js",
+      "name": "./node_modules/core-js/modules/_user-agent.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_user-agent.js",
+      "name": "./node_modules/core-js/modules/_user-agent.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_wks-define": [
+    {
+      "id": "./node_modules/core-js/modules/_wks-define.js",
+      "name": "./node_modules/core-js/modules/_wks-define.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_wks-define.js",
+      "name": "./node_modules/core-js/modules/_wks-define.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_wks-ext": [
+    {
+      "id": "./node_modules/core-js/modules/_wks-ext.js",
+      "name": "./node_modules/core-js/modules/_wks-ext.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_wks-ext.js",
+      "name": "./node_modules/core-js/modules/_wks-ext.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_wks": [
+    {
+      "id": "./node_modules/core-js/modules/_wks.js",
+      "name": "./node_modules/core-js/modules/_wks.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_wks.js",
+      "name": "./node_modules/core-js/modules/_wks.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./core.get-iterator-method": [
+    {
+      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es6.array.iterator": [
+    {
+      "id": "./node_modules/core-js/modules/es6.array.iterator.js",
+      "name": "./node_modules/core-js/modules/es6.array.iterator.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.array.iterator.js",
+      "name": "./node_modules/core-js/modules/es6.array.iterator.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es6.function.name": [
+    {
+      "id": "./node_modules/core-js/modules/es6.function.name.js",
+      "name": "./node_modules/core-js/modules/es6.function.name.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.function.name.js",
+      "name": "./node_modules/core-js/modules/es6.function.name.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es6.object.keys": [
+    {
+      "id": "./node_modules/core-js/modules/es6.object.keys.js",
+      "name": "./node_modules/core-js/modules/es6.object.keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.object.keys.js",
+      "name": "./node_modules/core-js/modules/es6.object.keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es6.object.set-prototype-of": [
+    {
+      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es6.promise": [
+    {
+      "id": "./node_modules/core-js/modules/es6.promise.js",
+      "name": "./node_modules/core-js/modules/es6.promise.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.promise.js",
+      "name": "./node_modules/core-js/modules/es6.promise.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./es6.regexp.exec": [
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es6.regexp.match": [
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es6.symbol": [
+    {
+      "id": "./node_modules/core-js/modules/es6.symbol.js",
+      "name": "./node_modules/core-js/modules/es6.symbol.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.symbol.js",
+      "name": "./node_modules/core-js/modules/es6.symbol.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/es7.symbol.async-iterator": [
+    {
+      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "core-js/modules/web.dom.iterable": [
+    {
+      "id": "./node_modules/core-js/modules/web.dom.iterable.js",
+      "name": "./node_modules/core-js/modules/web.dom.iterable.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/web.dom.iterable.js",
+      "name": "./node_modules/core-js/modules/web.dom.iterable.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./implementation": [
+    {
+      "id": "./node_modules/create-react-context/lib/implementation.js",
+      "name": "./node_modules/create-react-context/lib/implementation.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/create-react-context/lib/implementation.js",
+      "name": "./node_modules/create-react-context/lib/implementation.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "create-react-context": [
+    {
+      "id": "./node_modules/create-react-context/lib/index.js",
+      "name": "./node_modules/create-react-context/lib/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/create-react-context/lib/index.js",
+      "name": "./node_modules/create-react-context/lib/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "!../css-hot-loader/hotModuleReplacement.js": [
+    {
+      "id": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "name": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "name": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "deep-equal": [
+    {
+      "id": "./node_modules/deep-equal/index.js",
+      "name": "./node_modules/deep-equal/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/deep-equal/index.js",
+      "name": "./node_modules/deep-equal/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./lib/is_arguments.js": [
+    {
+      "id": "./node_modules/deep-equal/lib/is_arguments.js",
+      "name": "./node_modules/deep-equal/lib/is_arguments.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/deep-equal/lib/is_arguments.js",
+      "name": "./node_modules/deep-equal/lib/is_arguments.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./lib/keys.js": [
+    {
+      "id": "./node_modules/deep-equal/lib/keys.js",
+      "name": "./node_modules/deep-equal/lib/keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/deep-equal/lib/keys.js",
+      "name": "./node_modules/deep-equal/lib/keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "exenv": [
+    {
+      "id": "./node_modules/exenv/index.js",
+      "name": "./node_modules/exenv/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/exenv/index.js",
+      "name": "./node_modules/exenv/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -963,150 +2051,58 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "!!webpack amd define": [
+  "./emptyFunction": [
     {
-      "id": "./node_modules/webpack/buildin/amd-define.js",
-      "name": "./node_modules/webpack/buildin/amd-define.js",
+      "id": "./node_modules/fbjs/lib/emptyFunction.js",
+      "name": "./node_modules/fbjs/lib/emptyFunction.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/webpack/buildin/amd-define.js",
-      "name": "./node_modules/webpack/buildin/amd-define.js",
+      "id": "./node_modules/fbjs/lib/emptyFunction.js",
+      "name": "./node_modules/fbjs/lib/emptyFunction.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "!!webpack amd options": [
+  "fbjs/lib/warning": [
     {
-      "id": "./node_modules/webpack/buildin/amd-options.js",
-      "name": "./node_modules/webpack/buildin/amd-options.js",
+      "id": "./node_modules/fbjs/lib/warning.js",
+      "name": "./node_modules/fbjs/lib/warning.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/webpack/buildin/amd-options.js",
-      "name": "./node_modules/webpack/buildin/amd-options.js",
+      "id": "./node_modules/fbjs/lib/warning.js",
+      "name": "./node_modules/fbjs/lib/warning.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "hoist-non-react-statics": [
+  "gud": [
     {
-      "id": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-      "name": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "id": "./node_modules/gud/index.js",
+      "name": "./node_modules/gud/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-      "name": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "id": "./node_modules/gud/index.js",
+      "name": "./node_modules/gud/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "lodash.merge": [
+  "./DOMUtils": [
     {
-      "id": "./node_modules/lodash.merge/index.js",
-      "name": "./node_modules/lodash.merge/index.js",
+      "id": "./node_modules/history/es/DOMUtils.js",
+      "name": "./node_modules/history/es/DOMUtils.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash.merge/index.js",
-      "name": "./node_modules/lodash.merge/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "history": [
-    {
-      "id": "./node_modules/history/es/index.js",
-      "name": "./node_modules/history/es/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/history/esm/history.js",
-      "name": "./node_modules/react-router/node_modules/history/esm/history.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
-      "name": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/history/es/index.js",
-      "name": "./node_modules/history/es/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/history/esm/history.js",
-      "name": "./node_modules/react-router/node_modules/history/esm/history.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
-      "name": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./createBrowserHistory": [
-    {
-      "id": "./node_modules/history/es/createBrowserHistory.js",
-      "name": "./node_modules/history/es/createBrowserHistory.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/history/es/createBrowserHistory.js",
-      "name": "./node_modules/history/es/createBrowserHistory.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "warning": [
-    {
-      "id": "./node_modules/warning/browser.js",
-      "name": "./node_modules/warning/browser.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/warning/browser.js",
-      "name": "./node_modules/warning/browser.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "invariant": [
-    {
-      "id": "./node_modules/invariant/browser.js",
-      "name": "./node_modules/invariant/browser.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/invariant/browser.js",
-      "name": "./node_modules/invariant/browser.js",
+      "id": "./node_modules/history/es/DOMUtils.js",
+      "name": "./node_modules/history/es/DOMUtils.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -1125,34 +2121,6 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "resolve-pathname": [
-    {
-      "id": "./node_modules/resolve-pathname/index.js",
-      "name": "./node_modules/resolve-pathname/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/resolve-pathname/index.js",
-      "name": "./node_modules/resolve-pathname/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "value-equal": [
-    {
-      "id": "./node_modules/value-equal/index.js",
-      "name": "./node_modules/value-equal/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/value-equal/index.js",
-      "name": "./node_modules/value-equal/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
   "./PathUtils": [
     {
       "id": "./node_modules/history/es/PathUtils.js",
@@ -1167,30 +2135,16 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "./createTransitionManager": [
+  "./createBrowserHistory": [
     {
-      "id": "./node_modules/history/es/createTransitionManager.js",
-      "name": "./node_modules/history/es/createTransitionManager.js",
+      "id": "./node_modules/history/es/createBrowserHistory.js",
+      "name": "./node_modules/history/es/createBrowserHistory.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/history/es/createTransitionManager.js",
-      "name": "./node_modules/history/es/createTransitionManager.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./DOMUtils": [
-    {
-      "id": "./node_modules/history/es/DOMUtils.js",
-      "name": "./node_modules/history/es/DOMUtils.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/history/es/DOMUtils.js",
-      "name": "./node_modules/history/es/DOMUtils.js",
+      "id": "./node_modules/history/es/createBrowserHistory.js",
+      "name": "./node_modules/history/es/createBrowserHistory.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -1223,56 +2177,1312 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "react-redux": [
+  "./createTransitionManager": [
     {
-      "id": "./node_modules/react-redux/es/index.js",
-      "name": "./node_modules/react-redux/es/index.js",
+      "id": "./node_modules/history/es/createTransitionManager.js",
+      "name": "./node_modules/history/es/createTransitionManager.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-redux/es/index.js",
-      "name": "./node_modules/react-redux/es/index.js",
+      "id": "./node_modules/history/es/createTransitionManager.js",
+      "name": "./node_modules/history/es/createTransitionManager.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./components/Provider": [
+  "history": [
     {
-      "id": "./node_modules/react-redux/es/components/Provider.js",
-      "name": "./node_modules/react-redux/es/components/Provider.js",
+      "id": "./node_modules/history/es/index.js",
+      "name": "./node_modules/history/es/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-redux/es/components/Provider.js",
-      "name": "./node_modules/react-redux/es/components/Provider.js",
+      "id": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
+      "name": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-router/node_modules/history/esm/history.js",
+      "name": "./node_modules/react-router/node_modules/history/esm/history.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/history/es/index.js",
+      "name": "./node_modules/history/es/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
+      "name": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-router/node_modules/history/esm/history.js",
+      "name": "./node_modules/react-router/node_modules/history/esm/history.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "@babel/runtime/helpers/esm/inheritsLoose": [
+  "hoist-non-react-statics": [
     {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "id": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "name": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
-      "name": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "id": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "name": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
-      "name": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "html-entities": [
+    {
+      "id": "./node_modules/html-entities/index.js",
+      "name": "./node_modules/html-entities/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/html-entities/index.js",
+      "name": "./node_modules/html-entities/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./lib/html4-entities.js": [
+    {
+      "id": "./node_modules/html-entities/lib/html4-entities.js",
+      "name": "./node_modules/html-entities/lib/html4-entities.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/html-entities/lib/html4-entities.js",
+      "name": "./node_modules/html-entities/lib/html4-entities.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./lib/html5-entities.js": [
+    {
+      "id": "./node_modules/html-entities/lib/html5-entities.js",
+      "name": "./node_modules/html-entities/lib/html5-entities.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/html-entities/lib/html5-entities.js",
+      "name": "./node_modules/html-entities/lib/html5-entities.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./lib/xml-entities.js": [
+    {
+      "id": "./node_modules/html-entities/lib/xml-entities.js",
+      "name": "./node_modules/html-entities/lib/xml-entities.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/html-entities/lib/xml-entities.js",
+      "name": "./node_modules/html-entities/lib/xml-entities.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "invariant": [
+    {
+      "id": "./node_modules/invariant/browser.js",
+      "name": "./node_modules/invariant/browser.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/invariant/browser.js",
+      "name": "./node_modules/invariant/browser.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "is-buffer": [
+    {
+      "id": "./node_modules/is-buffer/index.js",
+      "name": "./node_modules/is-buffer/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/is-buffer/index.js",
+      "name": "./node_modules/is-buffer/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "is-plain-obj": [
+    {
+      "id": "./node_modules/is-plain-obj/index.js",
+      "name": "./node_modules/is-plain-obj/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/is-plain-obj/index.js",
+      "name": "./node_modules/is-plain-obj/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "lodash.merge": [
+    {
+      "id": "./node_modules/lodash.merge/index.js",
+      "name": "./node_modules/lodash.merge/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash.merge/index.js",
+      "name": "./node_modules/lodash.merge/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_Symbol": [
+    {
+      "id": "./node_modules/lodash/_Symbol.js",
+      "name": "./node_modules/lodash/_Symbol.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_Symbol.js",
+      "name": "./node_modules/lodash/_Symbol.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_apply": [
+    {
+      "id": "./node_modules/lodash/_apply.js",
+      "name": "./node_modules/lodash/_apply.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_apply.js",
+      "name": "./node_modules/lodash/_apply.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_arrayLikeKeys": [
+    {
+      "id": "./node_modules/lodash/_arrayLikeKeys.js",
+      "name": "./node_modules/lodash/_arrayLikeKeys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_arrayLikeKeys.js",
+      "name": "./node_modules/lodash/_arrayLikeKeys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_assignValue": [
+    {
+      "id": "./node_modules/lodash/_assignValue.js",
+      "name": "./node_modules/lodash/_assignValue.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_assignValue.js",
+      "name": "./node_modules/lodash/_assignValue.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseAssignValue": [
+    {
+      "id": "./node_modules/lodash/_baseAssignValue.js",
+      "name": "./node_modules/lodash/_baseAssignValue.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseAssignValue.js",
+      "name": "./node_modules/lodash/_baseAssignValue.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseGetTag": [
+    {
+      "id": "./node_modules/lodash/_baseGetTag.js",
+      "name": "./node_modules/lodash/_baseGetTag.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseGetTag.js",
+      "name": "./node_modules/lodash/_baseGetTag.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseIsArguments": [
+    {
+      "id": "./node_modules/lodash/_baseIsArguments.js",
+      "name": "./node_modules/lodash/_baseIsArguments.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseIsArguments.js",
+      "name": "./node_modules/lodash/_baseIsArguments.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseIsNative": [
+    {
+      "id": "./node_modules/lodash/_baseIsNative.js",
+      "name": "./node_modules/lodash/_baseIsNative.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseIsNative.js",
+      "name": "./node_modules/lodash/_baseIsNative.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseIsTypedArray": [
+    {
+      "id": "./node_modules/lodash/_baseIsTypedArray.js",
+      "name": "./node_modules/lodash/_baseIsTypedArray.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseIsTypedArray.js",
+      "name": "./node_modules/lodash/_baseIsTypedArray.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseKeys": [
+    {
+      "id": "./node_modules/lodash/_baseKeys.js",
+      "name": "./node_modules/lodash/_baseKeys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseKeys.js",
+      "name": "./node_modules/lodash/_baseKeys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseRest": [
+    {
+      "id": "./node_modules/lodash/_baseRest.js",
+      "name": "./node_modules/lodash/_baseRest.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseRest.js",
+      "name": "./node_modules/lodash/_baseRest.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseSetToString": [
+    {
+      "id": "./node_modules/lodash/_baseSetToString.js",
+      "name": "./node_modules/lodash/_baseSetToString.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseSetToString.js",
+      "name": "./node_modules/lodash/_baseSetToString.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseTimes": [
+    {
+      "id": "./node_modules/lodash/_baseTimes.js",
+      "name": "./node_modules/lodash/_baseTimes.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseTimes.js",
+      "name": "./node_modules/lodash/_baseTimes.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_baseUnary": [
+    {
+      "id": "./node_modules/lodash/_baseUnary.js",
+      "name": "./node_modules/lodash/_baseUnary.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseUnary.js",
+      "name": "./node_modules/lodash/_baseUnary.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_copyObject": [
+    {
+      "id": "./node_modules/lodash/_copyObject.js",
+      "name": "./node_modules/lodash/_copyObject.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_copyObject.js",
+      "name": "./node_modules/lodash/_copyObject.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_coreJsData": [
+    {
+      "id": "./node_modules/lodash/_coreJsData.js",
+      "name": "./node_modules/lodash/_coreJsData.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_coreJsData.js",
+      "name": "./node_modules/lodash/_coreJsData.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_createAssigner": [
+    {
+      "id": "./node_modules/lodash/_createAssigner.js",
+      "name": "./node_modules/lodash/_createAssigner.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_createAssigner.js",
+      "name": "./node_modules/lodash/_createAssigner.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_defineProperty": [
+    {
+      "id": "./node_modules/lodash/_defineProperty.js",
+      "name": "./node_modules/lodash/_defineProperty.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_defineProperty.js",
+      "name": "./node_modules/lodash/_defineProperty.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_freeGlobal": [
+    {
+      "id": "./node_modules/lodash/_freeGlobal.js",
+      "name": "./node_modules/lodash/_freeGlobal.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_freeGlobal.js",
+      "name": "./node_modules/lodash/_freeGlobal.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_getNative": [
+    {
+      "id": "./node_modules/lodash/_getNative.js",
+      "name": "./node_modules/lodash/_getNative.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_getNative.js",
+      "name": "./node_modules/lodash/_getNative.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_getRawTag": [
+    {
+      "id": "./node_modules/lodash/_getRawTag.js",
+      "name": "./node_modules/lodash/_getRawTag.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_getRawTag.js",
+      "name": "./node_modules/lodash/_getRawTag.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_getValue": [
+    {
+      "id": "./node_modules/lodash/_getValue.js",
+      "name": "./node_modules/lodash/_getValue.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_getValue.js",
+      "name": "./node_modules/lodash/_getValue.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_isIndex": [
+    {
+      "id": "./node_modules/lodash/_isIndex.js",
+      "name": "./node_modules/lodash/_isIndex.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isIndex.js",
+      "name": "./node_modules/lodash/_isIndex.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_isIterateeCall": [
+    {
+      "id": "./node_modules/lodash/_isIterateeCall.js",
+      "name": "./node_modules/lodash/_isIterateeCall.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isIterateeCall.js",
+      "name": "./node_modules/lodash/_isIterateeCall.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_isMasked": [
+    {
+      "id": "./node_modules/lodash/_isMasked.js",
+      "name": "./node_modules/lodash/_isMasked.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isMasked.js",
+      "name": "./node_modules/lodash/_isMasked.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_isPrototype": [
+    {
+      "id": "./node_modules/lodash/_isPrototype.js",
+      "name": "./node_modules/lodash/_isPrototype.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isPrototype.js",
+      "name": "./node_modules/lodash/_isPrototype.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_nativeKeys": [
+    {
+      "id": "./node_modules/lodash/_nativeKeys.js",
+      "name": "./node_modules/lodash/_nativeKeys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_nativeKeys.js",
+      "name": "./node_modules/lodash/_nativeKeys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_nodeUtil": [
+    {
+      "id": "./node_modules/lodash/_nodeUtil.js",
+      "name": "./node_modules/lodash/_nodeUtil.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_nodeUtil.js",
+      "name": "./node_modules/lodash/_nodeUtil.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_objectToString": [
+    {
+      "id": "./node_modules/lodash/_objectToString.js",
+      "name": "./node_modules/lodash/_objectToString.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_objectToString.js",
+      "name": "./node_modules/lodash/_objectToString.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_overArg": [
+    {
+      "id": "./node_modules/lodash/_overArg.js",
+      "name": "./node_modules/lodash/_overArg.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_overArg.js",
+      "name": "./node_modules/lodash/_overArg.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_overRest": [
+    {
+      "id": "./node_modules/lodash/_overRest.js",
+      "name": "./node_modules/lodash/_overRest.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_overRest.js",
+      "name": "./node_modules/lodash/_overRest.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_root": [
+    {
+      "id": "./node_modules/lodash/_root.js",
+      "name": "./node_modules/lodash/_root.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_root.js",
+      "name": "./node_modules/lodash/_root.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_setToString": [
+    {
+      "id": "./node_modules/lodash/_setToString.js",
+      "name": "./node_modules/lodash/_setToString.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_setToString.js",
+      "name": "./node_modules/lodash/_setToString.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_shortOut": [
+    {
+      "id": "./node_modules/lodash/_shortOut.js",
+      "name": "./node_modules/lodash/_shortOut.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_shortOut.js",
+      "name": "./node_modules/lodash/_shortOut.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./_toSource": [
+    {
+      "id": "./node_modules/lodash/_toSource.js",
+      "name": "./node_modules/lodash/_toSource.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_toSource.js",
+      "name": "./node_modules/lodash/_toSource.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "lodash/assign": [
+    {
+      "id": "./node_modules/lodash/assign.js",
+      "name": "./node_modules/lodash/assign.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/assign.js",
+      "name": "./node_modules/lodash/assign.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./constant": [
+    {
+      "id": "./node_modules/lodash/constant.js",
+      "name": "./node_modules/lodash/constant.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/constant.js",
+      "name": "./node_modules/lodash/constant.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "lodash/debounce": [
+    {
+      "id": "./node_modules/lodash/debounce.js",
+      "name": "./node_modules/lodash/debounce.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/debounce.js",
+      "name": "./node_modules/lodash/debounce.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./eq": [
+    {
+      "id": "./node_modules/lodash/eq.js",
+      "name": "./node_modules/lodash/eq.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/eq.js",
+      "name": "./node_modules/lodash/eq.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./identity": [
+    {
+      "id": "./node_modules/lodash/identity.js",
+      "name": "./node_modules/lodash/identity.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/identity.js",
+      "name": "./node_modules/lodash/identity.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isArguments": [
+    {
+      "id": "./node_modules/lodash/isArguments.js",
+      "name": "./node_modules/lodash/isArguments.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isArguments.js",
+      "name": "./node_modules/lodash/isArguments.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isArray": [
+    {
+      "id": "./node_modules/lodash/isArray.js",
+      "name": "./node_modules/lodash/isArray.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isArray.js",
+      "name": "./node_modules/lodash/isArray.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isArrayLike": [
+    {
+      "id": "./node_modules/lodash/isArrayLike.js",
+      "name": "./node_modules/lodash/isArrayLike.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isArrayLike.js",
+      "name": "./node_modules/lodash/isArrayLike.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isBuffer": [
+    {
+      "id": "./node_modules/lodash/isBuffer.js",
+      "name": "./node_modules/lodash/isBuffer.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isBuffer.js",
+      "name": "./node_modules/lodash/isBuffer.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isFunction": [
+    {
+      "id": "./node_modules/lodash/isFunction.js",
+      "name": "./node_modules/lodash/isFunction.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isFunction.js",
+      "name": "./node_modules/lodash/isFunction.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isLength": [
+    {
+      "id": "./node_modules/lodash/isLength.js",
+      "name": "./node_modules/lodash/isLength.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isLength.js",
+      "name": "./node_modules/lodash/isLength.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isObject": [
+    {
+      "id": "./node_modules/lodash/isObject.js",
+      "name": "./node_modules/lodash/isObject.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isObject.js",
+      "name": "./node_modules/lodash/isObject.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isObjectLike": [
+    {
+      "id": "./node_modules/lodash/isObjectLike.js",
+      "name": "./node_modules/lodash/isObjectLike.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isObjectLike.js",
+      "name": "./node_modules/lodash/isObjectLike.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isSymbol": [
+    {
+      "id": "./node_modules/lodash/isSymbol.js",
+      "name": "./node_modules/lodash/isSymbol.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isSymbol.js",
+      "name": "./node_modules/lodash/isSymbol.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./isTypedArray": [
+    {
+      "id": "./node_modules/lodash/isTypedArray.js",
+      "name": "./node_modules/lodash/isTypedArray.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isTypedArray.js",
+      "name": "./node_modules/lodash/isTypedArray.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./keys": [
+    {
+      "id": "./node_modules/lodash/keys.js",
+      "name": "./node_modules/lodash/keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/keys.js",
+      "name": "./node_modules/lodash/keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./now": [
+    {
+      "id": "./node_modules/lodash/now.js",
+      "name": "./node_modules/lodash/now.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/now.js",
+      "name": "./node_modules/lodash/now.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./stubFalse": [
+    {
+      "id": "./node_modules/lodash/stubFalse.js",
+      "name": "./node_modules/lodash/stubFalse.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/stubFalse.js",
+      "name": "./node_modules/lodash/stubFalse.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./toNumber": [
+    {
+      "id": "./node_modules/lodash/toNumber.js",
+      "name": "./node_modules/lodash/toNumber.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/toNumber.js",
+      "name": "./node_modules/lodash/toNumber.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./../../node_modules/node-libs-browser/node_modules/process/browser.js": [
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "name": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "name": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "punycode": [
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/punycode/punycode.js",
+      "name": "./node_modules/node-libs-browser/node_modules/punycode/punycode.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/punycode/punycode.js",
+      "name": "./node_modules/node-libs-browser/node_modules/punycode/punycode.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "normalize-url": [
+    {
+      "id": "./node_modules/normalize-url/index.js",
+      "name": "./node_modules/normalize-url/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/normalize-url/index.js",
+      "name": "./node_modules/normalize-url/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "normalize.css/normalize.css": [
+    {
+      "id": "./node_modules/normalize.css/normalize.css",
+      "name": "./node_modules/normalize.css/normalize.css",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/normalize.css/normalize.css",
+      "name": "./node_modules/normalize.css/normalize.css",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "object-assign": [
+    {
+      "id": "./node_modules/object-assign/index.js",
+      "name": "./node_modules/object-assign/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/object-assign/index.js",
+      "name": "./node_modules/object-assign/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "prepend-http": [
+    {
+      "id": "./node_modules/prepend-http/index.js",
+      "name": "./node_modules/prepend-http/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/prepend-http/index.js",
+      "name": "./node_modules/prepend-http/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "prop-types/checkPropTypes": [
+    {
+      "id": "./node_modules/prop-types/checkPropTypes.js",
+      "name": "./node_modules/prop-types/checkPropTypes.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/prop-types/checkPropTypes.js",
+      "name": "./node_modules/prop-types/checkPropTypes.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./factoryWithTypeCheckers": [
+    {
+      "id": "./node_modules/prop-types/factoryWithTypeCheckers.js",
+      "name": "./node_modules/prop-types/factoryWithTypeCheckers.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/prop-types/factoryWithTypeCheckers.js",
+      "name": "./node_modules/prop-types/factoryWithTypeCheckers.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "prop-types": [
+    {
+      "id": "./node_modules/prop-types/index.js",
+      "name": "./node_modules/prop-types/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/prop-types/index.js",
+      "name": "./node_modules/prop-types/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./lib/ReactPropTypesSecret": [
+    {
+      "id": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "name": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "name": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "query-string": [
+    {
+      "id": "./node_modules/query-string/index.js",
+      "name": "./node_modules/query-string/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/query-string/index.js",
+      "name": "./node_modules/query-string/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./decode": [
+    {
+      "id": "./node_modules/querystring-es3/decode.js",
+      "name": "./node_modules/querystring-es3/decode.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/querystring-es3/decode.js",
+      "name": "./node_modules/querystring-es3/decode.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./encode": [
+    {
+      "id": "./node_modules/querystring-es3/encode.js",
+      "name": "./node_modules/querystring-es3/encode.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/querystring-es3/encode.js",
+      "name": "./node_modules/querystring-es3/encode.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "querystring": [
+    {
+      "id": "./node_modules/querystring-es3/index.js",
+      "name": "./node_modules/querystring-es3/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/querystring-es3/index.js",
+      "name": "./node_modules/querystring-es3/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./cjs/react-dom.development.js": [
+    {
+      "id": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "name": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "name": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "react-dom": [
+    {
+      "id": "./node_modules/react-dom/index.js",
+      "name": "./node_modules/react-dom/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-dom/index.js",
+      "name": "./node_modules/react-dom/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "react-helmet": [
+    {
+      "id": "./node_modules/react-helmet/lib/Helmet.js",
+      "name": "./node_modules/react-helmet/lib/Helmet.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-helmet/lib/Helmet.js",
+      "name": "./node_modules/react-helmet/lib/Helmet.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./HelmetConstants.js": [
+    {
+      "id": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "name": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "name": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./HelmetUtils.js": [
+    {
+      "id": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "name": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "name": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./dist/react-hot-loader.development.js": [
+    {
+      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./dist/react-hot-loader.production.min.js": [
+    {
+      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "react-hot-loader": [
+    {
+      "id": "./node_modules/react-hot-loader/index.js",
+      "name": "./node_modules/react-hot-loader/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-hot-loader/index.js",
+      "name": "./node_modules/react-hot-loader/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./cjs/react-is.development.js": [
+    {
+      "id": "./node_modules/react-is/cjs/react-is.development.js",
+      "name": "./node_modules/react-is/cjs/react-is.development.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-is/cjs/react-is.development.js",
+      "name": "./node_modules/react-is/cjs/react-is.development.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "react-is": [
+    {
+      "id": "./node_modules/react-is/index.js",
+      "name": "./node_modules/react-is/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-is/index.js",
+      "name": "./node_modules/react-is/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "react-lifecycles-compat": [
+    {
+      "id": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "name": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "name": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "react-loadable": [
+    {
+      "id": "./node_modules/react-loadable/lib/index.js",
+      "name": "./node_modules/react-loadable/lib/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-loadable/lib/index.js",
+      "name": "./node_modules/react-loadable/lib/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -1291,6 +3501,20 @@
       "publicPath": "/assets/main.js"
     }
   ],
+  "./components/Provider": [
+    {
+      "id": "./node_modules/react-redux/es/components/Provider.js",
+      "name": "./node_modules/react-redux/es/components/Provider.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/react-redux/es/components/Provider.js",
+      "name": "./node_modules/react-redux/es/components/Provider.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
   "./components/connectAdvanced": [
     {
       "id": "./node_modules/react-redux/es/components/connectAdvanced.js",
@@ -1301,172 +3525,6 @@
     {
       "id": "./node_modules/react-redux/es/components/connectAdvanced.js",
       "name": "./node_modules/react-redux/es/components/connectAdvanced.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "@babel/runtime/helpers/esm/assertThisInitialized": [
-    {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "@babel/runtime/helpers/esm/extends": [
-    {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/extends.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/extends.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/@babel/runtime/helpers/esm/extends.js",
-      "name": "./node_modules/@babel/runtime/helpers/esm/extends.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/extends.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/extends.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/@babel/runtime/helpers/esm/extends.js",
-      "name": "./node_modules/@babel/runtime/helpers/esm/extends.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "@babel/runtime/helpers/esm/objectWithoutPropertiesLoose": [
-    {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "name": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "name": "./node_modules/react-redux/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "name": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "react-is": [
-    {
-      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/index.js",
-      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/react-is/index.js",
-      "name": "./node_modules/react-redux/node_modules/react-is/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-is/index.js",
-      "name": "./node_modules/react-is/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/react-is/index.js",
-      "name": "./node_modules/react-router/node_modules/react-is/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/index.js",
-      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/react-is/index.js",
-      "name": "./node_modules/react-redux/node_modules/react-is/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-is/index.js",
-      "name": "./node_modules/react-is/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/react-is/index.js",
-      "name": "./node_modules/react-router/node_modules/react-is/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./cjs/react-is.development.js": [
-    {
-      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/cjs/react-is.development.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-redux/node_modules/react-is/cjs/react-is.development.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-is/cjs/react-is.development.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-router/node_modules/react-is/cjs/react-is.development.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/node_modules/react-is/cjs/react-is.development.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-redux/node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-redux/node_modules/react-is/cjs/react-is.development.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-is/cjs/react-is.development.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/react-is/cjs/react-is.development.js",
-      "name": "./node_modules/react-router/node_modules/react-is/cjs/react-is.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -1485,20 +3543,6 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "../utils/shallowEqual": [
-    {
-      "id": "./node_modules/react-redux/es/utils/shallowEqual.js",
-      "name": "./node_modules/react-redux/es/utils/shallowEqual.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/es/utils/shallowEqual.js",
-      "name": "./node_modules/react-redux/es/utils/shallowEqual.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
   "./mapDispatchToProps": [
     {
       "id": "./node_modules/react-redux/es/connect/mapDispatchToProps.js",
@@ -1509,104 +3553,6 @@
     {
       "id": "./node_modules/react-redux/es/connect/mapDispatchToProps.js",
       "name": "./node_modules/react-redux/es/connect/mapDispatchToProps.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "redux": [
-    {
-      "id": "./node_modules/redux/es/redux.js",
-      "name": "./node_modules/redux/es/redux.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/redux/es/redux.js",
-      "name": "./node_modules/redux/es/redux.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "symbol-observable": [
-    {
-      "id": "./node_modules/symbol-observable/es/index.js",
-      "name": "./node_modules/symbol-observable/es/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/symbol-observable/es/index.js",
-      "name": "./node_modules/symbol-observable/es/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./ponyfill.js": [
-    {
-      "id": "./node_modules/symbol-observable/es/ponyfill.js",
-      "name": "./node_modules/symbol-observable/es/ponyfill.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/symbol-observable/es/ponyfill.js",
-      "name": "./node_modules/symbol-observable/es/ponyfill.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./wrapMapToProps": [
-    {
-      "id": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
-      "name": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
-      "name": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "../utils/verifyPlainObject": [
-    {
-      "id": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
-      "name": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
-      "name": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isPlainObject": [
-    {
-      "id": "./node_modules/react-redux/es/utils/isPlainObject.js",
-      "name": "./node_modules/react-redux/es/utils/isPlainObject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/es/utils/isPlainObject.js",
-      "name": "./node_modules/react-redux/es/utils/isPlainObject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./warning": [
-    {
-      "id": "./node_modules/react-redux/es/utils/warning.js",
-      "name": "./node_modules/react-redux/es/utils/warning.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-redux/es/utils/warning.js",
-      "name": "./node_modules/react-redux/es/utils/warning.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -1667,280 +3613,86 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "connected-react-router": [
+  "./wrapMapToProps": [
     {
-      "id": "./node_modules/connected-react-router/esm/index.js",
-      "name": "./node_modules/connected-react-router/esm/index.js",
+      "id": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
+      "name": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/connected-react-router/esm/index.js",
-      "name": "./node_modules/connected-react-router/esm/index.js",
+      "id": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
+      "name": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./ConnectedRouter": [
+  "react-redux": [
     {
-      "id": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
-      "name": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
+      "id": "./node_modules/react-redux/es/index.js",
+      "name": "./node_modules/react-redux/es/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
-      "name": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
+      "id": "./node_modules/react-redux/es/index.js",
+      "name": "./node_modules/react-redux/es/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "react-router": [
+  "./isPlainObject": [
     {
-      "id": "./node_modules/react-router/esm/react-router.js",
-      "name": "./node_modules/react-router/esm/react-router.js",
+      "id": "./node_modules/react-redux/es/utils/isPlainObject.js",
+      "name": "./node_modules/react-redux/es/utils/isPlainObject.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-router/esm/react-router.js",
-      "name": "./node_modules/react-router/esm/react-router.js",
+      "id": "./node_modules/react-redux/es/utils/isPlainObject.js",
+      "name": "./node_modules/react-redux/es/utils/isPlainObject.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "create-react-context": [
+  "../utils/shallowEqual": [
     {
-      "id": "./node_modules/react-router/node_modules/create-react-context/lib/index.js",
-      "name": "./node_modules/react-router/node_modules/create-react-context/lib/index.js",
+      "id": "./node_modules/react-redux/es/utils/shallowEqual.js",
+      "name": "./node_modules/react-redux/es/utils/shallowEqual.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-router/node_modules/create-react-context/lib/index.js",
-      "name": "./node_modules/react-router/node_modules/create-react-context/lib/index.js",
+      "id": "./node_modules/react-redux/es/utils/shallowEqual.js",
+      "name": "./node_modules/react-redux/es/utils/shallowEqual.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./implementation": [
+  "../utils/verifyPlainObject": [
     {
-      "id": "./node_modules/react-router/node_modules/create-react-context/lib/implementation.js",
-      "name": "./node_modules/react-router/node_modules/create-react-context/lib/implementation.js",
+      "id": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
+      "name": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-router/node_modules/create-react-context/lib/implementation.js",
-      "name": "./node_modules/react-router/node_modules/create-react-context/lib/implementation.js",
+      "id": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
+      "name": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "gud": [
+  "../utils/warning": [
     {
-      "id": "./node_modules/gud/index.js",
-      "name": "./node_modules/gud/index.js",
+      "id": "./node_modules/react-redux/es/utils/warning.js",
+      "name": "./node_modules/react-redux/es/utils/warning.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/gud/index.js",
-      "name": "./node_modules/gud/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "fbjs/lib/warning": [
-    {
-      "id": "./node_modules/fbjs/lib/warning.js",
-      "name": "./node_modules/fbjs/lib/warning.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/fbjs/lib/warning.js",
-      "name": "./node_modules/fbjs/lib/warning.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./emptyFunction": [
-    {
-      "id": "./node_modules/fbjs/lib/emptyFunction.js",
-      "name": "./node_modules/fbjs/lib/emptyFunction.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/fbjs/lib/emptyFunction.js",
-      "name": "./node_modules/fbjs/lib/emptyFunction.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "tiny-warning": [
-    {
-      "id": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
-      "name": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
-      "name": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "tiny-invariant": [
-    {
-      "id": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
-      "name": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
-      "name": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "path-to-regexp": [
-    {
-      "id": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
-      "name": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
-      "name": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "isarray": [
-    {
-      "id": "./node_modules/react-router/node_modules/isarray/index.js",
-      "name": "./node_modules/react-router/node_modules/isarray/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router/node_modules/isarray/index.js",
-      "name": "./node_modules/react-router/node_modules/isarray/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./actions": [
-    {
-      "id": "./node_modules/connected-react-router/esm/actions.js",
-      "name": "./node_modules/connected-react-router/esm/actions.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/actions/index.js",
-      "name": "./src/actions/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/connected-react-router/esm/actions.js",
-      "name": "./node_modules/connected-react-router/esm/actions.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./src/actions/index.js",
-      "name": "./src/actions/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./selectors": [
-    {
-      "id": "./node_modules/connected-react-router/esm/selectors.js",
-      "name": "./node_modules/connected-react-router/esm/selectors.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/connected-react-router/esm/selectors.js",
-      "name": "./node_modules/connected-react-router/esm/selectors.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./reducer": [
-    {
-      "id": "./node_modules/connected-react-router/esm/reducer.js",
-      "name": "./node_modules/connected-react-router/esm/reducer.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/connected-react-router/esm/reducer.js",
-      "name": "./node_modules/connected-react-router/esm/reducer.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./structure/plain": [
-    {
-      "id": "./node_modules/connected-react-router/esm/structure/plain/index.js",
-      "name": "./node_modules/connected-react-router/esm/structure/plain/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/connected-react-router/esm/structure/plain/index.js",
-      "name": "./node_modules/connected-react-router/esm/structure/plain/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./getIn": [
-    {
-      "id": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
-      "name": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
-      "name": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./middleware": [
-    {
-      "id": "./node_modules/connected-react-router/esm/middleware.js",
-      "name": "./node_modules/connected-react-router/esm/middleware.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/connected-react-router/esm/middleware.js",
-      "name": "./node_modules/connected-react-router/esm/middleware.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "react-router-dom": [
-    {
-      "id": "./node_modules/react-router-dom/esm/react-router-dom.js",
-      "name": "./node_modules/react-router-dom/esm/react-router-dom.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-router-dom/esm/react-router-dom.js",
-      "name": "./node_modules/react-router-dom/esm/react-router-dom.js",
+      "id": "./node_modules/react-redux/es/utils/warning.js",
+      "name": "./node_modules/react-redux/es/utils/warning.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -1959,2268 +3711,58 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "react-loadable": [
+  "react-router-dom": [
     {
-      "id": "./node_modules/react-loadable/lib/index.js",
-      "name": "./node_modules/react-loadable/lib/index.js",
+      "id": "./node_modules/react-router-dom/esm/react-router-dom.js",
+      "name": "./node_modules/react-router-dom/esm/react-router-dom.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-loadable/lib/index.js",
-      "name": "./node_modules/react-loadable/lib/index.js",
+      "id": "./node_modules/react-router-dom/esm/react-router-dom.js",
+      "name": "./node_modules/react-router-dom/esm/react-router-dom.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./utils/configureStore": [
+  "react-router": [
     {
-      "id": "./src/utils/configureStore.js",
-      "name": "./src/utils/configureStore.js",
+      "id": "./node_modules/react-router/esm/react-router.js",
+      "name": "./node_modules/react-router/esm/react-router.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/utils/configureStore.js",
-      "name": "./src/utils/configureStore.js",
+      "id": "./node_modules/react-router/esm/react-router.js",
+      "name": "./node_modules/react-router/esm/react-router.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "redux-thunk": [
+  "isarray": [
     {
-      "id": "./node_modules/redux-thunk/es/index.js",
-      "name": "./node_modules/redux-thunk/es/index.js",
+      "id": "./node_modules/react-router/node_modules/isarray/index.js",
+      "name": "./node_modules/react-router/node_modules/isarray/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/redux-thunk/es/index.js",
-      "name": "./node_modules/redux-thunk/es/index.js",
+      "id": "./node_modules/react-router/node_modules/isarray/index.js",
+      "name": "./node_modules/react-router/node_modules/isarray/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "../reducers": [
+  "path-to-regexp": [
     {
-      "id": "./src/reducers/index.js",
-      "name": "./src/reducers/index.js",
+      "id": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
+      "name": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/reducers/index.js",
-      "name": "./src/reducers/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/web.dom.iterable": [
-    {
-      "id": "./node_modules/core-js/modules/web.dom.iterable.js",
-      "name": "./node_modules/core-js/modules/web.dom.iterable.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/web.dom.iterable.js",
-      "name": "./node_modules/core-js/modules/web.dom.iterable.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.array.iterator": [
-    {
-      "id": "./node_modules/core-js/modules/es6.array.iterator.js",
-      "name": "./node_modules/core-js/modules/es6.array.iterator.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.array.iterator.js",
-      "name": "./node_modules/core-js/modules/es6.array.iterator.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_add-to-unscopables": [
-    {
-      "id": "./node_modules/core-js/modules/_add-to-unscopables.js",
-      "name": "./node_modules/core-js/modules/_add-to-unscopables.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_add-to-unscopables.js",
-      "name": "./node_modules/core-js/modules/_add-to-unscopables.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_wks": [
-    {
-      "id": "./node_modules/core-js/modules/_wks.js",
-      "name": "./node_modules/core-js/modules/_wks.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_wks.js",
-      "name": "./node_modules/core-js/modules/_wks.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_shared": [
-    {
-      "id": "./node_modules/core-js/modules/_shared.js",
-      "name": "./node_modules/core-js/modules/_shared.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_shared.js",
-      "name": "./node_modules/core-js/modules/_shared.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_core": [
-    {
-      "id": "./node_modules/core-js/modules/_core.js",
-      "name": "./node_modules/core-js/modules/_core.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_core.js",
-      "name": "./node_modules/core-js/modules/_core.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_global": [
-    {
-      "id": "./node_modules/core-js/modules/_global.js",
-      "name": "./node_modules/core-js/modules/_global.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_global.js",
-      "name": "./node_modules/core-js/modules/_global.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_library": [
-    {
-      "id": "./node_modules/core-js/modules/_library.js",
-      "name": "./node_modules/core-js/modules/_library.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_library.js",
-      "name": "./node_modules/core-js/modules/_library.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_uid": [
-    {
-      "id": "./node_modules/core-js/modules/_uid.js",
-      "name": "./node_modules/core-js/modules/_uid.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_uid.js",
-      "name": "./node_modules/core-js/modules/_uid.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_hide": [
-    {
-      "id": "./node_modules/core-js/modules/_hide.js",
-      "name": "./node_modules/core-js/modules/_hide.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_hide.js",
-      "name": "./node_modules/core-js/modules/_hide.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-dp": [
-    {
-      "id": "./node_modules/core-js/modules/_object-dp.js",
-      "name": "./node_modules/core-js/modules/_object-dp.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-dp.js",
-      "name": "./node_modules/core-js/modules/_object-dp.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_an-object": [
-    {
-      "id": "./node_modules/core-js/modules/_an-object.js",
-      "name": "./node_modules/core-js/modules/_an-object.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_an-object.js",
-      "name": "./node_modules/core-js/modules/_an-object.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_is-object": [
-    {
-      "id": "./node_modules/core-js/modules/_is-object.js",
-      "name": "./node_modules/core-js/modules/_is-object.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_is-object.js",
-      "name": "./node_modules/core-js/modules/_is-object.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_ie8-dom-define": [
-    {
-      "id": "./node_modules/core-js/modules/_ie8-dom-define.js",
-      "name": "./node_modules/core-js/modules/_ie8-dom-define.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_ie8-dom-define.js",
-      "name": "./node_modules/core-js/modules/_ie8-dom-define.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_descriptors": [
-    {
-      "id": "./node_modules/core-js/modules/_descriptors.js",
-      "name": "./node_modules/core-js/modules/_descriptors.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_descriptors.js",
-      "name": "./node_modules/core-js/modules/_descriptors.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_fails": [
-    {
-      "id": "./node_modules/core-js/modules/_fails.js",
-      "name": "./node_modules/core-js/modules/_fails.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_fails.js",
-      "name": "./node_modules/core-js/modules/_fails.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_dom-create": [
-    {
-      "id": "./node_modules/core-js/modules/_dom-create.js",
-      "name": "./node_modules/core-js/modules/_dom-create.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_dom-create.js",
-      "name": "./node_modules/core-js/modules/_dom-create.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_to-primitive": [
-    {
-      "id": "./node_modules/core-js/modules/_to-primitive.js",
-      "name": "./node_modules/core-js/modules/_to-primitive.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_to-primitive.js",
-      "name": "./node_modules/core-js/modules/_to-primitive.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_property-desc": [
-    {
-      "id": "./node_modules/core-js/modules/_property-desc.js",
-      "name": "./node_modules/core-js/modules/_property-desc.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_property-desc.js",
-      "name": "./node_modules/core-js/modules/_property-desc.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iter-step": [
-    {
-      "id": "./node_modules/core-js/modules/_iter-step.js",
-      "name": "./node_modules/core-js/modules/_iter-step.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_iter-step.js",
-      "name": "./node_modules/core-js/modules/_iter-step.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iterators": [
-    {
-      "id": "./node_modules/core-js/modules/_iterators.js",
-      "name": "./node_modules/core-js/modules/_iterators.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_iterators.js",
-      "name": "./node_modules/core-js/modules/_iterators.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_to-iobject": [
-    {
-      "id": "./node_modules/core-js/modules/_to-iobject.js",
-      "name": "./node_modules/core-js/modules/_to-iobject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_to-iobject.js",
-      "name": "./node_modules/core-js/modules/_to-iobject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iobject": [
-    {
-      "id": "./node_modules/core-js/modules/_iobject.js",
-      "name": "./node_modules/core-js/modules/_iobject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_iobject.js",
-      "name": "./node_modules/core-js/modules/_iobject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_cof": [
-    {
-      "id": "./node_modules/core-js/modules/_cof.js",
-      "name": "./node_modules/core-js/modules/_cof.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_cof.js",
-      "name": "./node_modules/core-js/modules/_cof.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_defined": [
-    {
-      "id": "./node_modules/core-js/modules/_defined.js",
-      "name": "./node_modules/core-js/modules/_defined.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_defined.js",
-      "name": "./node_modules/core-js/modules/_defined.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iter-define": [
-    {
-      "id": "./node_modules/core-js/modules/_iter-define.js",
-      "name": "./node_modules/core-js/modules/_iter-define.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_iter-define.js",
-      "name": "./node_modules/core-js/modules/_iter-define.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_export": [
-    {
-      "id": "./node_modules/core-js/modules/_export.js",
-      "name": "./node_modules/core-js/modules/_export.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_export.js",
-      "name": "./node_modules/core-js/modules/_export.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_redefine": [
-    {
-      "id": "./node_modules/core-js/modules/_redefine.js",
-      "name": "./node_modules/core-js/modules/_redefine.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_redefine.js",
-      "name": "./node_modules/core-js/modules/_redefine.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_has": [
-    {
-      "id": "./node_modules/core-js/modules/_has.js",
-      "name": "./node_modules/core-js/modules/_has.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_has.js",
-      "name": "./node_modules/core-js/modules/_has.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_ctx": [
-    {
-      "id": "./node_modules/core-js/modules/_ctx.js",
-      "name": "./node_modules/core-js/modules/_ctx.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_ctx.js",
-      "name": "./node_modules/core-js/modules/_ctx.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_a-function": [
-    {
-      "id": "./node_modules/core-js/modules/_a-function.js",
-      "name": "./node_modules/core-js/modules/_a-function.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_a-function.js",
-      "name": "./node_modules/core-js/modules/_a-function.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iter-create": [
-    {
-      "id": "./node_modules/core-js/modules/_iter-create.js",
-      "name": "./node_modules/core-js/modules/_iter-create.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_iter-create.js",
-      "name": "./node_modules/core-js/modules/_iter-create.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-create": [
-    {
-      "id": "./node_modules/core-js/modules/_object-create.js",
-      "name": "./node_modules/core-js/modules/_object-create.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-create.js",
-      "name": "./node_modules/core-js/modules/_object-create.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-dps": [
-    {
-      "id": "./node_modules/core-js/modules/_object-dps.js",
-      "name": "./node_modules/core-js/modules/_object-dps.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-dps.js",
-      "name": "./node_modules/core-js/modules/_object-dps.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-keys": [
-    {
-      "id": "./node_modules/core-js/modules/_object-keys.js",
-      "name": "./node_modules/core-js/modules/_object-keys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-keys.js",
-      "name": "./node_modules/core-js/modules/_object-keys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-keys-internal": [
-    {
-      "id": "./node_modules/core-js/modules/_object-keys-internal.js",
-      "name": "./node_modules/core-js/modules/_object-keys-internal.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-keys-internal.js",
-      "name": "./node_modules/core-js/modules/_object-keys-internal.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_array-includes": [
-    {
-      "id": "./node_modules/core-js/modules/_array-includes.js",
-      "name": "./node_modules/core-js/modules/_array-includes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_array-includes.js",
-      "name": "./node_modules/core-js/modules/_array-includes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_to-length": [
-    {
-      "id": "./node_modules/core-js/modules/_to-length.js",
-      "name": "./node_modules/core-js/modules/_to-length.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_to-length.js",
-      "name": "./node_modules/core-js/modules/_to-length.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_to-integer": [
-    {
-      "id": "./node_modules/core-js/modules/_to-integer.js",
-      "name": "./node_modules/core-js/modules/_to-integer.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_to-integer.js",
-      "name": "./node_modules/core-js/modules/_to-integer.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_to-absolute-index": [
-    {
-      "id": "./node_modules/core-js/modules/_to-absolute-index.js",
-      "name": "./node_modules/core-js/modules/_to-absolute-index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_to-absolute-index.js",
-      "name": "./node_modules/core-js/modules/_to-absolute-index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_shared-key": [
-    {
-      "id": "./node_modules/core-js/modules/_shared-key.js",
-      "name": "./node_modules/core-js/modules/_shared-key.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_shared-key.js",
-      "name": "./node_modules/core-js/modules/_shared-key.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_enum-bug-keys": [
-    {
-      "id": "./node_modules/core-js/modules/_enum-bug-keys.js",
-      "name": "./node_modules/core-js/modules/_enum-bug-keys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_enum-bug-keys.js",
-      "name": "./node_modules/core-js/modules/_enum-bug-keys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_html": [
-    {
-      "id": "./node_modules/core-js/modules/_html.js",
-      "name": "./node_modules/core-js/modules/_html.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_html.js",
-      "name": "./node_modules/core-js/modules/_html.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_set-to-string-tag": [
-    {
-      "id": "./node_modules/core-js/modules/_set-to-string-tag.js",
-      "name": "./node_modules/core-js/modules/_set-to-string-tag.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_set-to-string-tag.js",
-      "name": "./node_modules/core-js/modules/_set-to-string-tag.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gpo": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gpo.js",
-      "name": "./node_modules/core-js/modules/_object-gpo.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-gpo.js",
-      "name": "./node_modules/core-js/modules/_object-gpo.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_to-object": [
-    {
-      "id": "./node_modules/core-js/modules/_to-object.js",
-      "name": "./node_modules/core-js/modules/_to-object.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_to-object.js",
-      "name": "./node_modules/core-js/modules/_to-object.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.object.keys": [
-    {
-      "id": "./node_modules/core-js/modules/es6.object.keys.js",
-      "name": "./node_modules/core-js/modules/es6.object.keys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.object.keys.js",
-      "name": "./node_modules/core-js/modules/es6.object.keys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-sap": [
-    {
-      "id": "./node_modules/core-js/modules/_object-sap.js",
-      "name": "./node_modules/core-js/modules/_object-sap.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-sap.js",
-      "name": "./node_modules/core-js/modules/_object-sap.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "webpack-hot-middleware/client?reload=true": [
-    {
-      "id": "./node_modules/webpack-hot-middleware/client.js?reload=true",
-      "name": "./node_modules/webpack-hot-middleware/client.js?reload=true",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/webpack-hot-middleware/client.js?reload=true",
-      "name": "./node_modules/webpack-hot-middleware/client.js?reload=true",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "lodash/assign": [
-    {
-      "id": "./node_modules/lodash/assign.js",
-      "name": "./node_modules/lodash/assign.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/assign.js",
-      "name": "./node_modules/lodash/assign.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_assignValue": [
-    {
-      "id": "./node_modules/lodash/_assignValue.js",
-      "name": "./node_modules/lodash/_assignValue.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_assignValue.js",
-      "name": "./node_modules/lodash/_assignValue.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseAssignValue": [
-    {
-      "id": "./node_modules/lodash/_baseAssignValue.js",
-      "name": "./node_modules/lodash/_baseAssignValue.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseAssignValue.js",
-      "name": "./node_modules/lodash/_baseAssignValue.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_defineProperty": [
-    {
-      "id": "./node_modules/lodash/_defineProperty.js",
-      "name": "./node_modules/lodash/_defineProperty.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_defineProperty.js",
-      "name": "./node_modules/lodash/_defineProperty.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_getNative": [
-    {
-      "id": "./node_modules/lodash/_getNative.js",
-      "name": "./node_modules/lodash/_getNative.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_getNative.js",
-      "name": "./node_modules/lodash/_getNative.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseIsNative": [
-    {
-      "id": "./node_modules/lodash/_baseIsNative.js",
-      "name": "./node_modules/lodash/_baseIsNative.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseIsNative.js",
-      "name": "./node_modules/lodash/_baseIsNative.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isFunction": [
-    {
-      "id": "./node_modules/lodash/isFunction.js",
-      "name": "./node_modules/lodash/isFunction.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isFunction.js",
-      "name": "./node_modules/lodash/isFunction.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseGetTag": [
-    {
-      "id": "./node_modules/lodash/_baseGetTag.js",
-      "name": "./node_modules/lodash/_baseGetTag.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_baseGetTag.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_baseGetTag.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseGetTag.js",
-      "name": "./node_modules/lodash/_baseGetTag.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_baseGetTag.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_baseGetTag.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_Symbol": [
-    {
-      "id": "./node_modules/lodash/_Symbol.js",
-      "name": "./node_modules/lodash/_Symbol.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_Symbol.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_Symbol.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_Symbol.js",
-      "name": "./node_modules/lodash/_Symbol.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_Symbol.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_Symbol.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_root": [
-    {
-      "id": "./node_modules/lodash/_root.js",
-      "name": "./node_modules/lodash/_root.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_root.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_root.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_root.js",
-      "name": "./node_modules/lodash/_root.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_root.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_root.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_freeGlobal": [
-    {
-      "id": "./node_modules/lodash/_freeGlobal.js",
-      "name": "./node_modules/lodash/_freeGlobal.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_freeGlobal.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_freeGlobal.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_freeGlobal.js",
-      "name": "./node_modules/lodash/_freeGlobal.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_freeGlobal.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_freeGlobal.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_getRawTag": [
-    {
-      "id": "./node_modules/lodash/_getRawTag.js",
-      "name": "./node_modules/lodash/_getRawTag.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_getRawTag.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_getRawTag.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_getRawTag.js",
-      "name": "./node_modules/lodash/_getRawTag.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_getRawTag.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_getRawTag.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_objectToString": [
-    {
-      "id": "./node_modules/lodash/_objectToString.js",
-      "name": "./node_modules/lodash/_objectToString.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_objectToString.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_objectToString.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_objectToString.js",
-      "name": "./node_modules/lodash/_objectToString.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/_objectToString.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/_objectToString.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isObject": [
-    {
-      "id": "./node_modules/lodash/isObject.js",
-      "name": "./node_modules/lodash/isObject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/isObject.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/isObject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isObject.js",
-      "name": "./node_modules/lodash/isObject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/isObject.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/isObject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isMasked": [
-    {
-      "id": "./node_modules/lodash/_isMasked.js",
-      "name": "./node_modules/lodash/_isMasked.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isMasked.js",
-      "name": "./node_modules/lodash/_isMasked.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_coreJsData": [
-    {
-      "id": "./node_modules/lodash/_coreJsData.js",
-      "name": "./node_modules/lodash/_coreJsData.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_coreJsData.js",
-      "name": "./node_modules/lodash/_coreJsData.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_toSource": [
-    {
-      "id": "./node_modules/lodash/_toSource.js",
-      "name": "./node_modules/lodash/_toSource.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_toSource.js",
-      "name": "./node_modules/lodash/_toSource.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_getValue": [
-    {
-      "id": "./node_modules/lodash/_getValue.js",
-      "name": "./node_modules/lodash/_getValue.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_getValue.js",
-      "name": "./node_modules/lodash/_getValue.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./eq": [
-    {
-      "id": "./node_modules/lodash/eq.js",
-      "name": "./node_modules/lodash/eq.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/eq.js",
-      "name": "./node_modules/lodash/eq.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_copyObject": [
-    {
-      "id": "./node_modules/lodash/_copyObject.js",
-      "name": "./node_modules/lodash/_copyObject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_copyObject.js",
-      "name": "./node_modules/lodash/_copyObject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_createAssigner": [
-    {
-      "id": "./node_modules/lodash/_createAssigner.js",
-      "name": "./node_modules/lodash/_createAssigner.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_createAssigner.js",
-      "name": "./node_modules/lodash/_createAssigner.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseRest": [
-    {
-      "id": "./node_modules/lodash/_baseRest.js",
-      "name": "./node_modules/lodash/_baseRest.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseRest.js",
-      "name": "./node_modules/lodash/_baseRest.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./identity": [
-    {
-      "id": "./node_modules/lodash/identity.js",
-      "name": "./node_modules/lodash/identity.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/identity.js",
-      "name": "./node_modules/lodash/identity.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_overRest": [
-    {
-      "id": "./node_modules/lodash/_overRest.js",
-      "name": "./node_modules/lodash/_overRest.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_overRest.js",
-      "name": "./node_modules/lodash/_overRest.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_apply": [
-    {
-      "id": "./node_modules/lodash/_apply.js",
-      "name": "./node_modules/lodash/_apply.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_apply.js",
-      "name": "./node_modules/lodash/_apply.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_setToString": [
-    {
-      "id": "./node_modules/lodash/_setToString.js",
-      "name": "./node_modules/lodash/_setToString.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_setToString.js",
-      "name": "./node_modules/lodash/_setToString.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseSetToString": [
-    {
-      "id": "./node_modules/lodash/_baseSetToString.js",
-      "name": "./node_modules/lodash/_baseSetToString.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseSetToString.js",
-      "name": "./node_modules/lodash/_baseSetToString.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./constant": [
-    {
-      "id": "./node_modules/lodash/constant.js",
-      "name": "./node_modules/lodash/constant.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/constant.js",
-      "name": "./node_modules/lodash/constant.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_shortOut": [
-    {
-      "id": "./node_modules/lodash/_shortOut.js",
-      "name": "./node_modules/lodash/_shortOut.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_shortOut.js",
-      "name": "./node_modules/lodash/_shortOut.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isIterateeCall": [
-    {
-      "id": "./node_modules/lodash/_isIterateeCall.js",
-      "name": "./node_modules/lodash/_isIterateeCall.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isIterateeCall.js",
-      "name": "./node_modules/lodash/_isIterateeCall.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isArrayLike": [
-    {
-      "id": "./node_modules/lodash/isArrayLike.js",
-      "name": "./node_modules/lodash/isArrayLike.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isArrayLike.js",
-      "name": "./node_modules/lodash/isArrayLike.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isLength": [
-    {
-      "id": "./node_modules/lodash/isLength.js",
-      "name": "./node_modules/lodash/isLength.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isLength.js",
-      "name": "./node_modules/lodash/isLength.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isIndex": [
-    {
-      "id": "./node_modules/lodash/_isIndex.js",
-      "name": "./node_modules/lodash/_isIndex.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isIndex.js",
-      "name": "./node_modules/lodash/_isIndex.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isPrototype": [
-    {
-      "id": "./node_modules/lodash/_isPrototype.js",
-      "name": "./node_modules/lodash/_isPrototype.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isPrototype.js",
-      "name": "./node_modules/lodash/_isPrototype.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./keys": [
-    {
-      "id": "./node_modules/lodash/keys.js",
-      "name": "./node_modules/lodash/keys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/keys.js",
-      "name": "./node_modules/lodash/keys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_arrayLikeKeys": [
-    {
-      "id": "./node_modules/lodash/_arrayLikeKeys.js",
-      "name": "./node_modules/lodash/_arrayLikeKeys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_arrayLikeKeys.js",
-      "name": "./node_modules/lodash/_arrayLikeKeys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseTimes": [
-    {
-      "id": "./node_modules/lodash/_baseTimes.js",
-      "name": "./node_modules/lodash/_baseTimes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseTimes.js",
-      "name": "./node_modules/lodash/_baseTimes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isArguments": [
-    {
-      "id": "./node_modules/lodash/isArguments.js",
-      "name": "./node_modules/lodash/isArguments.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isArguments.js",
-      "name": "./node_modules/lodash/isArguments.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseIsArguments": [
-    {
-      "id": "./node_modules/lodash/_baseIsArguments.js",
-      "name": "./node_modules/lodash/_baseIsArguments.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseIsArguments.js",
-      "name": "./node_modules/lodash/_baseIsArguments.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isObjectLike": [
-    {
-      "id": "./node_modules/lodash/isObjectLike.js",
-      "name": "./node_modules/lodash/isObjectLike.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/isObjectLike.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/isObjectLike.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isObjectLike.js",
-      "name": "./node_modules/lodash/isObjectLike.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/isObjectLike.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/isObjectLike.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isArray": [
-    {
-      "id": "./node_modules/lodash/isArray.js",
-      "name": "./node_modules/lodash/isArray.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isArray.js",
-      "name": "./node_modules/lodash/isArray.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isBuffer": [
-    {
-      "id": "./node_modules/lodash/isBuffer.js",
-      "name": "./node_modules/lodash/isBuffer.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isBuffer.js",
-      "name": "./node_modules/lodash/isBuffer.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./stubFalse": [
-    {
-      "id": "./node_modules/lodash/stubFalse.js",
-      "name": "./node_modules/lodash/stubFalse.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/stubFalse.js",
-      "name": "./node_modules/lodash/stubFalse.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isTypedArray": [
-    {
-      "id": "./node_modules/lodash/isTypedArray.js",
-      "name": "./node_modules/lodash/isTypedArray.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isTypedArray.js",
-      "name": "./node_modules/lodash/isTypedArray.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseIsTypedArray": [
-    {
-      "id": "./node_modules/lodash/_baseIsTypedArray.js",
-      "name": "./node_modules/lodash/_baseIsTypedArray.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseIsTypedArray.js",
-      "name": "./node_modules/lodash/_baseIsTypedArray.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseUnary": [
-    {
-      "id": "./node_modules/lodash/_baseUnary.js",
-      "name": "./node_modules/lodash/_baseUnary.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseUnary.js",
-      "name": "./node_modules/lodash/_baseUnary.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_nodeUtil": [
-    {
-      "id": "./node_modules/lodash/_nodeUtil.js",
-      "name": "./node_modules/lodash/_nodeUtil.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_nodeUtil.js",
-      "name": "./node_modules/lodash/_nodeUtil.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseKeys": [
-    {
-      "id": "./node_modules/lodash/_baseKeys.js",
-      "name": "./node_modules/lodash/_baseKeys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseKeys.js",
-      "name": "./node_modules/lodash/_baseKeys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_nativeKeys": [
-    {
-      "id": "./node_modules/lodash/_nativeKeys.js",
-      "name": "./node_modules/lodash/_nativeKeys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_nativeKeys.js",
-      "name": "./node_modules/lodash/_nativeKeys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_overArg": [
-    {
-      "id": "./node_modules/lodash/_overArg.js",
-      "name": "./node_modules/lodash/_overArg.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_overArg.js",
-      "name": "./node_modules/lodash/_overArg.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./userInfo": [
-    {
-      "id": "./src/reducers/userInfo.js",
-      "name": "./src/reducers/userInfo.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/reducers/userInfo.js",
-      "name": "./src/reducers/userInfo.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./routes": [
-    {
-      "id": "./src/routes.js",
-      "name": "./src/routes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/routes.js",
-      "name": "./src/routes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./users": [
-    {
-      "id": "./src/actions/users.js",
-      "name": "./src/actions/users.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/actions/users.js",
-      "name": "./src/actions/users.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.promise": [
-    {
-      "id": "./node_modules/core-js/modules/es6.promise.js",
-      "name": "./node_modules/core-js/modules/es6.promise.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.promise.js",
-      "name": "./node_modules/core-js/modules/es6.promise.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_classof": [
-    {
-      "id": "./node_modules/core-js/modules/_classof.js",
-      "name": "./node_modules/core-js/modules/_classof.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_classof.js",
-      "name": "./node_modules/core-js/modules/_classof.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_an-instance": [
-    {
-      "id": "./node_modules/core-js/modules/_an-instance.js",
-      "name": "./node_modules/core-js/modules/_an-instance.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_an-instance.js",
-      "name": "./node_modules/core-js/modules/_an-instance.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_for-of": [
-    {
-      "id": "./node_modules/core-js/modules/_for-of.js",
-      "name": "./node_modules/core-js/modules/_for-of.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_for-of.js",
-      "name": "./node_modules/core-js/modules/_for-of.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iter-call": [
-    {
-      "id": "./node_modules/core-js/modules/_iter-call.js",
-      "name": "./node_modules/core-js/modules/_iter-call.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_iter-call.js",
-      "name": "./node_modules/core-js/modules/_iter-call.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_is-array-iter": [
-    {
-      "id": "./node_modules/core-js/modules/_is-array-iter.js",
-      "name": "./node_modules/core-js/modules/_is-array-iter.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_is-array-iter.js",
-      "name": "./node_modules/core-js/modules/_is-array-iter.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./core.get-iterator-method": [
-    {
-      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_species-constructor": [
-    {
-      "id": "./node_modules/core-js/modules/_species-constructor.js",
-      "name": "./node_modules/core-js/modules/_species-constructor.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_species-constructor.js",
-      "name": "./node_modules/core-js/modules/_species-constructor.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_task": [
-    {
-      "id": "./node_modules/core-js/modules/_task.js",
-      "name": "./node_modules/core-js/modules/_task.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_task.js",
-      "name": "./node_modules/core-js/modules/_task.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_invoke": [
-    {
-      "id": "./node_modules/core-js/modules/_invoke.js",
-      "name": "./node_modules/core-js/modules/_invoke.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_invoke.js",
-      "name": "./node_modules/core-js/modules/_invoke.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_microtask": [
-    {
-      "id": "./node_modules/core-js/modules/_microtask.js",
-      "name": "./node_modules/core-js/modules/_microtask.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_microtask.js",
-      "name": "./node_modules/core-js/modules/_microtask.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_new-promise-capability": [
-    {
-      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_perform": [
-    {
-      "id": "./node_modules/core-js/modules/_perform.js",
-      "name": "./node_modules/core-js/modules/_perform.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_perform.js",
-      "name": "./node_modules/core-js/modules/_perform.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_user-agent": [
-    {
-      "id": "./node_modules/core-js/modules/_user-agent.js",
-      "name": "./node_modules/core-js/modules/_user-agent.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_user-agent.js",
-      "name": "./node_modules/core-js/modules/_user-agent.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_promise-resolve": [
-    {
-      "id": "./node_modules/core-js/modules/_promise-resolve.js",
-      "name": "./node_modules/core-js/modules/_promise-resolve.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_promise-resolve.js",
-      "name": "./node_modules/core-js/modules/_promise-resolve.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_redefine-all": [
-    {
-      "id": "./node_modules/core-js/modules/_redefine-all.js",
-      "name": "./node_modules/core-js/modules/_redefine-all.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_redefine-all.js",
-      "name": "./node_modules/core-js/modules/_redefine-all.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_set-species": [
-    {
-      "id": "./node_modules/core-js/modules/_set-species.js",
-      "name": "./node_modules/core-js/modules/_set-species.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_set-species.js",
-      "name": "./node_modules/core-js/modules/_set-species.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iter-detect": [
-    {
-      "id": "./node_modules/core-js/modules/_iter-detect.js",
-      "name": "./node_modules/core-js/modules/_iter-detect.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_iter-detect.js",
-      "name": "./node_modules/core-js/modules/_iter-detect.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "regenerator-runtime/runtime": [
-    {
-      "id": "./node_modules/regenerator-runtime/runtime.js",
-      "name": "./node_modules/regenerator-runtime/runtime.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/regenerator-runtime/runtime.js",
-      "name": "./node_modules/regenerator-runtime/runtime.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "axios": [
-    {
-      "id": "./node_modules/axios/index.js",
-      "name": "./node_modules/axios/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/index.js",
-      "name": "./node_modules/axios/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./lib/axios": [
-    {
-      "id": "./node_modules/axios/lib/axios.js",
-      "name": "./node_modules/axios/lib/axios.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/axios.js",
-      "name": "./node_modules/axios/lib/axios.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./utils": [
-    {
-      "id": "./node_modules/axios/lib/utils.js",
-      "name": "./node_modules/axios/lib/utils.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/utils.js",
-      "name": "./node_modules/axios/lib/utils.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./helpers/bind": [
-    {
-      "id": "./node_modules/axios/lib/helpers/bind.js",
-      "name": "./node_modules/axios/lib/helpers/bind.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/bind.js",
-      "name": "./node_modules/axios/lib/helpers/bind.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "is-buffer": [
-    {
-      "id": "./node_modules/is-buffer/index.js",
-      "name": "./node_modules/is-buffer/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/is-buffer/index.js",
-      "name": "./node_modules/is-buffer/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./core/Axios": [
-    {
-      "id": "./node_modules/axios/lib/core/Axios.js",
-      "name": "./node_modules/axios/lib/core/Axios.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/core/Axios.js",
-      "name": "./node_modules/axios/lib/core/Axios.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./defaults": [
-    {
-      "id": "./node_modules/axios/lib/defaults.js",
-      "name": "./node_modules/axios/lib/defaults.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/defaults.js",
-      "name": "./node_modules/axios/lib/defaults.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../../node_modules/process/browser.js": [
-    {
-      "id": "./node_modules/process/browser.js",
-      "name": "./node_modules/process/browser.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/process/browser.js",
-      "name": "./node_modules/process/browser.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./helpers/normalizeHeaderName": [
-    {
-      "id": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
-      "name": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
-      "name": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./adapters/xhr": [
-    {
-      "id": "./node_modules/axios/lib/adapters/xhr.js",
-      "name": "./node_modules/axios/lib/adapters/xhr.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/adapters/xhr.js",
-      "name": "./node_modules/axios/lib/adapters/xhr.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../core/settle": [
-    {
-      "id": "./node_modules/axios/lib/core/settle.js",
-      "name": "./node_modules/axios/lib/core/settle.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/core/settle.js",
-      "name": "./node_modules/axios/lib/core/settle.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "../core/createError": [
-    {
-      "id": "./node_modules/axios/lib/core/createError.js",
-      "name": "./node_modules/axios/lib/core/createError.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/core/createError.js",
-      "name": "./node_modules/axios/lib/core/createError.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./enhanceError": [
-    {
-      "id": "./node_modules/axios/lib/core/enhanceError.js",
-      "name": "./node_modules/axios/lib/core/enhanceError.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/core/enhanceError.js",
-      "name": "./node_modules/axios/lib/core/enhanceError.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../helpers/buildURL": [
-    {
-      "id": "./node_modules/axios/lib/helpers/buildURL.js",
-      "name": "./node_modules/axios/lib/helpers/buildURL.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/buildURL.js",
-      "name": "./node_modules/axios/lib/helpers/buildURL.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../helpers/parseHeaders": [
-    {
-      "id": "./node_modules/axios/lib/helpers/parseHeaders.js",
-      "name": "./node_modules/axios/lib/helpers/parseHeaders.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/parseHeaders.js",
-      "name": "./node_modules/axios/lib/helpers/parseHeaders.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../helpers/isURLSameOrigin": [
-    {
-      "id": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
-      "name": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
-      "name": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../helpers/btoa": [
-    {
-      "id": "./node_modules/axios/lib/helpers/btoa.js",
-      "name": "./node_modules/axios/lib/helpers/btoa.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/btoa.js",
-      "name": "./node_modules/axios/lib/helpers/btoa.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../helpers/cookies": [
-    {
-      "id": "./node_modules/axios/lib/helpers/cookies.js",
-      "name": "./node_modules/axios/lib/helpers/cookies.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/cookies.js",
-      "name": "./node_modules/axios/lib/helpers/cookies.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./InterceptorManager": [
-    {
-      "id": "./node_modules/axios/lib/core/InterceptorManager.js",
-      "name": "./node_modules/axios/lib/core/InterceptorManager.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/core/InterceptorManager.js",
-      "name": "./node_modules/axios/lib/core/InterceptorManager.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./dispatchRequest": [
-    {
-      "id": "./node_modules/axios/lib/core/dispatchRequest.js",
-      "name": "./node_modules/axios/lib/core/dispatchRequest.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/core/dispatchRequest.js",
-      "name": "./node_modules/axios/lib/core/dispatchRequest.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./transformData": [
-    {
-      "id": "./node_modules/axios/lib/core/transformData.js",
-      "name": "./node_modules/axios/lib/core/transformData.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/core/transformData.js",
-      "name": "./node_modules/axios/lib/core/transformData.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./cancel/isCancel": [
-    {
-      "id": "./node_modules/axios/lib/cancel/isCancel.js",
-      "name": "./node_modules/axios/lib/cancel/isCancel.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/cancel/isCancel.js",
-      "name": "./node_modules/axios/lib/cancel/isCancel.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../helpers/isAbsoluteURL": [
-    {
-      "id": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
-      "name": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
-      "name": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../helpers/combineURLs": [
-    {
-      "id": "./node_modules/axios/lib/helpers/combineURLs.js",
-      "name": "./node_modules/axios/lib/helpers/combineURLs.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/combineURLs.js",
-      "name": "./node_modules/axios/lib/helpers/combineURLs.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./cancel/Cancel": [
-    {
-      "id": "./node_modules/axios/lib/cancel/Cancel.js",
-      "name": "./node_modules/axios/lib/cancel/Cancel.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/cancel/Cancel.js",
-      "name": "./node_modules/axios/lib/cancel/Cancel.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./cancel/CancelToken": [
-    {
-      "id": "./node_modules/axios/lib/cancel/CancelToken.js",
-      "name": "./node_modules/axios/lib/cancel/CancelToken.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/cancel/CancelToken.js",
-      "name": "./node_modules/axios/lib/cancel/CancelToken.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./helpers/spread": [
-    {
-      "id": "./node_modules/axios/lib/helpers/spread.js",
-      "name": "./node_modules/axios/lib/helpers/spread.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/axios/lib/helpers/spread.js",
-      "name": "./node_modules/axios/lib/helpers/spread.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./user": [
-    {
-      "id": "./src/actions/user.js",
-      "name": "./src/actions/user.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/actions/user.js",
-      "name": "./src/actions/user.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./app": [
-    {
-      "id": "./src/app/index.js",
-      "name": "./src/app/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/app/index.js",
-      "name": "./src/app/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "react-helmet": [
-    {
-      "id": "./node_modules/react-helmet/lib/Helmet.js",
-      "name": "./node_modules/react-helmet/lib/Helmet.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/react-helmet/lib/Helmet.js",
-      "name": "./node_modules/react-helmet/lib/Helmet.js",
+      "id": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
+      "name": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -4239,240 +3781,156 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "exenv": [
+  "./cjs/react.development.js": [
     {
-      "id": "./node_modules/exenv/index.js",
-      "name": "./node_modules/exenv/index.js",
+      "id": "./node_modules/react/cjs/react.development.js",
+      "name": "./node_modules/react/cjs/react.development.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/exenv/index.js",
-      "name": "./node_modules/exenv/index.js",
+      "id": "./node_modules/react/cjs/react.development.js",
+      "name": "./node_modules/react/cjs/react.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "deep-equal": [
+  "react": [
     {
-      "id": "./node_modules/deep-equal/index.js",
-      "name": "./node_modules/deep-equal/index.js",
+      "id": "./node_modules/react/index.js",
+      "name": "./node_modules/react/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/deep-equal/index.js",
-      "name": "./node_modules/deep-equal/index.js",
+      "id": "./node_modules/react/index.js",
+      "name": "./node_modules/react/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./lib/keys.js": [
+  "redux-thunk": [
     {
-      "id": "./node_modules/deep-equal/lib/keys.js",
-      "name": "./node_modules/deep-equal/lib/keys.js",
+      "id": "./node_modules/redux-thunk/es/index.js",
+      "name": "./node_modules/redux-thunk/es/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/deep-equal/lib/keys.js",
-      "name": "./node_modules/deep-equal/lib/keys.js",
+      "id": "./node_modules/redux-thunk/es/index.js",
+      "name": "./node_modules/redux-thunk/es/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./lib/is_arguments.js": [
+  "redux": [
     {
-      "id": "./node_modules/deep-equal/lib/is_arguments.js",
-      "name": "./node_modules/deep-equal/lib/is_arguments.js",
+      "id": "./node_modules/redux/es/redux.js",
+      "name": "./node_modules/redux/es/redux.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/deep-equal/lib/is_arguments.js",
-      "name": "./node_modules/deep-equal/lib/is_arguments.js",
+      "id": "./node_modules/redux/es/redux.js",
+      "name": "./node_modules/redux/es/redux.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./HelmetUtils.js": [
+  "regenerator-runtime/runtime": [
     {
-      "id": "./node_modules/react-helmet/lib/HelmetUtils.js",
-      "name": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "id": "./node_modules/regenerator-runtime/runtime.js",
+      "name": "./node_modules/regenerator-runtime/runtime.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-helmet/lib/HelmetUtils.js",
-      "name": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "id": "./node_modules/regenerator-runtime/runtime.js",
+      "name": "./node_modules/regenerator-runtime/runtime.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./HelmetConstants.js": [
+  "resolve-pathname": [
     {
-      "id": "./node_modules/react-helmet/lib/HelmetConstants.js",
-      "name": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "id": "./node_modules/resolve-pathname/index.js",
+      "name": "./node_modules/resolve-pathname/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/react-helmet/lib/HelmetConstants.js",
-      "name": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "id": "./node_modules/resolve-pathname/index.js",
+      "name": "./node_modules/resolve-pathname/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "../config": [
+  "./cjs/scheduler-tracing.development.js": [
     {
-      "id": "./src/config/index.js",
-      "name": "./src/config/index.js",
+      "id": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
+      "name": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/config/index.js",
-      "name": "./src/config/index.js",
+      "id": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
+      "name": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./default": [
+  "./cjs/scheduler.development.js": [
     {
-      "id": "./src/config/default.js",
-      "name": "./src/config/default.js",
+      "id": "./node_modules/scheduler/cjs/scheduler.development.js",
+      "name": "./node_modules/scheduler/cjs/scheduler.development.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/config/default.js",
-      "name": "./src/config/default.js",
+      "id": "./node_modules/scheduler/cjs/scheduler.development.js",
+      "name": "./node_modules/scheduler/cjs/scheduler.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "normalize.css/normalize.css": [
+  "scheduler": [
     {
-      "id": "./node_modules/normalize.css/normalize.css",
-      "name": "./node_modules/normalize.css/normalize.css",
+      "id": "./node_modules/scheduler/index.js",
+      "name": "./node_modules/scheduler/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/normalize.css/normalize.css",
-      "name": "./node_modules/normalize.css/normalize.css",
+      "id": "./node_modules/scheduler/index.js",
+      "name": "./node_modules/scheduler/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "!../css-hot-loader/hotModuleReplacement.js": [
+  "scheduler/tracing": [
     {
-      "id": "./node_modules/css-hot-loader/hotModuleReplacement.js",
-      "name": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "id": "./node_modules/scheduler/tracing.js",
+      "name": "./node_modules/scheduler/tracing.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/css-hot-loader/hotModuleReplacement.js",
-      "name": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "id": "./node_modules/scheduler/tracing.js",
+      "name": "./node_modules/scheduler/tracing.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "normalize-url": [
+  "shallowequal": [
     {
-      "id": "./node_modules/normalize-url/index.js",
-      "name": "./node_modules/normalize-url/index.js",
+      "id": "./node_modules/shallowequal/index.js",
+      "name": "./node_modules/shallowequal/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/normalize-url/index.js",
-      "name": "./node_modules/normalize-url/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "url": [
-    {
-      "id": "./node_modules/url/url.js",
-      "name": "./node_modules/url/url.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/url/url.js",
-      "name": "./node_modules/url/url.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "punycode": [
-    {
-      "id": "./node_modules/punycode/punycode.js",
-      "name": "./node_modules/punycode/punycode.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/punycode/punycode.js",
-      "name": "./node_modules/punycode/punycode.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./util": [
-    {
-      "id": "./node_modules/url/util.js",
-      "name": "./node_modules/url/util.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/url/util.js",
-      "name": "./node_modules/url/util.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "query-string": [
-    {
-      "id": "./node_modules/query-string/index.js",
-      "name": "./node_modules/query-string/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/query-string/index.js",
-      "name": "./node_modules/query-string/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "strict-uri-encode": [
-    {
-      "id": "./node_modules/strict-uri-encode/index.js",
-      "name": "./node_modules/strict-uri-encode/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/strict-uri-encode/index.js",
-      "name": "./node_modules/strict-uri-encode/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "prepend-http": [
-    {
-      "id": "./node_modules/prepend-http/index.js",
-      "name": "./node_modules/prepend-http/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/prepend-http/index.js",
-      "name": "./node_modules/prepend-http/index.js",
+      "id": "./node_modules/shallowequal/index.js",
+      "name": "./node_modules/shallowequal/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -4491,170 +3949,282 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "is-plain-obj": [
+  "strict-uri-encode": [
     {
-      "id": "./node_modules/is-plain-obj/index.js",
-      "name": "./node_modules/is-plain-obj/index.js",
+      "id": "./node_modules/strict-uri-encode/index.js",
+      "name": "./node_modules/strict-uri-encode/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/is-plain-obj/index.js",
-      "name": "./node_modules/is-plain-obj/index.js",
+      "id": "./node_modules/strict-uri-encode/index.js",
+      "name": "./node_modules/strict-uri-encode/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "lodash/debounce": [
+  "strip-ansi": [
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/debounce.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/debounce.js",
+      "id": "./node_modules/strip-ansi/index.js",
+      "name": "./node_modules/strip-ansi/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/debounce.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/debounce.js",
+      "id": "./node_modules/strip-ansi/index.js",
+      "name": "./node_modules/strip-ansi/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./now": [
+  "symbol-observable": [
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/now.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/now.js",
+      "id": "./node_modules/symbol-observable/es/index.js",
+      "name": "./node_modules/symbol-observable/es/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/now.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/now.js",
+      "id": "./node_modules/symbol-observable/es/index.js",
+      "name": "./node_modules/symbol-observable/es/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./toNumber": [
+  "./ponyfill.js": [
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/toNumber.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/toNumber.js",
+      "id": "./node_modules/symbol-observable/es/ponyfill.js",
+      "name": "./node_modules/symbol-observable/es/ponyfill.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/toNumber.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/toNumber.js",
+      "id": "./node_modules/symbol-observable/es/ponyfill.js",
+      "name": "./node_modules/symbol-observable/es/ponyfill.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./isSymbol": [
+  "tiny-invariant": [
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/isSymbol.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/isSymbol.js",
+      "id": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
+      "name": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/css-hot-loader/node_modules/lodash/isSymbol.js",
-      "name": "./node_modules/css-hot-loader/node_modules/lodash/isSymbol.js",
+      "id": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
+      "name": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./styles.scss": [
+  "tiny-warning": [
     {
-      "id": "./src/app/styles.scss",
-      "name": "./src/app/styles.scss",
+      "id": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
+      "name": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/UserList/styles.scss",
-      "name": "./src/components/UserList/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/UserCard/styles.scss",
-      "name": "./src/components/UserCard/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/ErrorDisplay/styles.scss",
-      "name": "./src/components/ErrorDisplay/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/Loading/styles.scss",
-      "name": "./src/components/Loading/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/pages/Home/styles.scss",
-      "name": "./src/pages/Home/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/pages/UserInfo/styles.scss",
-      "name": "./src/pages/UserInfo/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/pages/NotFound/styles.scss",
-      "name": "./src/pages/NotFound/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/app/styles.scss",
-      "name": "./src/app/styles.scss",
+      "id": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
+      "name": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    }
+  ],
+  "url": [
+    {
+      "id": "./node_modules/url/url.js",
+      "name": "./node_modules/url/url.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/UserList/styles.scss",
-      "name": "./src/components/UserList/styles.scss",
+      "id": "./node_modules/url/url.js",
+      "name": "./node_modules/url/url.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    }
+  ],
+  "./util": [
+    {
+      "id": "./node_modules/url/util.js",
+      "name": "./node_modules/url/util.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/UserCard/styles.scss",
-      "name": "./src/components/UserCard/styles.scss",
+      "id": "./node_modules/url/util.js",
+      "name": "./node_modules/url/util.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    }
+  ],
+  "value-equal": [
+    {
+      "id": "./node_modules/value-equal/index.js",
+      "name": "./node_modules/value-equal/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/ErrorDisplay/styles.scss",
-      "name": "./src/components/ErrorDisplay/styles.scss",
+      "id": "./node_modules/value-equal/index.js",
+      "name": "./node_modules/value-equal/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    }
+  ],
+  "warning": [
+    {
+      "id": "./node_modules/warning/browser.js",
+      "name": "./node_modules/warning/browser.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/Loading/styles.scss",
-      "name": "./src/components/Loading/styles.scss",
+      "id": "./node_modules/warning/browser.js",
+      "name": "./node_modules/warning/browser.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    }
+  ],
+  "./client-overlay": [
+    {
+      "id": "./node_modules/webpack-hot-middleware/client-overlay.js",
+      "name": "./node_modules/webpack-hot-middleware/client-overlay.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/pages/Home/styles.scss",
-      "name": "./src/pages/Home/styles.scss",
+      "id": "./node_modules/webpack-hot-middleware/client-overlay.js",
+      "name": "./node_modules/webpack-hot-middleware/client-overlay.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    }
+  ],
+  "webpack-hot-middleware/client?reload=true": [
+    {
+      "id": "./node_modules/webpack-hot-middleware/client.js?reload=true",
+      "name": "./node_modules/webpack-hot-middleware/client.js?reload=true",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/pages/UserInfo/styles.scss",
-      "name": "./src/pages/UserInfo/styles.scss",
+      "id": "./node_modules/webpack-hot-middleware/client.js?reload=true",
+      "name": "./node_modules/webpack-hot-middleware/client.js?reload=true",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    }
+  ],
+  "./process-update": [
+    {
+      "id": "./node_modules/webpack-hot-middleware/process-update.js",
+      "name": "./node_modules/webpack-hot-middleware/process-update.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/pages/NotFound/styles.scss",
-      "name": "./src/pages/NotFound/styles.scss",
+      "id": "./node_modules/webpack-hot-middleware/process-update.js",
+      "name": "./node_modules/webpack-hot-middleware/process-update.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "!!webpack amd define": [
+    {
+      "id": "./node_modules/webpack/buildin/amd-define.js",
+      "name": "./node_modules/webpack/buildin/amd-define.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/amd-define.js",
+      "name": "./node_modules/webpack/buildin/amd-define.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "!!webpack amd options": [
+    {
+      "id": "./node_modules/webpack/buildin/amd-options.js",
+      "name": "./node_modules/webpack/buildin/amd-options.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/amd-options.js",
+      "name": "./node_modules/webpack/buildin/amd-options.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./../../webpack/buildin/global.js": [
+    {
+      "id": "./node_modules/webpack/buildin/global.js",
+      "name": "./node_modules/webpack/buildin/global.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/global.js",
+      "name": "./node_modules/webpack/buildin/global.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./../node_modules/webpack/buildin/harmony-module.js": [
+    {
+      "id": "./node_modules/webpack/buildin/harmony-module.js",
+      "name": "./node_modules/webpack/buildin/harmony-module.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/harmony-module.js",
+      "name": "./node_modules/webpack/buildin/harmony-module.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./../webpack/buildin/module.js": [
+    {
+      "id": "./node_modules/webpack/buildin/module.js",
+      "name": "./node_modules/webpack/buildin/module.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/module.js",
+      "name": "./node_modules/webpack/buildin/module.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./user": [
+    {
+      "id": "./src/actions/user.js",
+      "name": "./src/actions/user.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/actions/user.js",
+      "name": "./src/actions/user.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./users": [
+    {
+      "id": "./src/actions/users.js",
+      "name": "./src/actions/users.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/actions/users.js",
+      "name": "./src/actions/users.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -4673,98 +4243,128 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "./pages": [
+  "./app": [
     {
-      "id": "./src/pages/index.js",
-      "name": "./src/pages/index.js",
+      "id": "./src/app/index.js",
+      "name": "./src/app/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/pages/index.js",
-      "name": "./src/pages/index.js",
+      "id": "./src/app/index.js",
+      "name": "./src/app/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./Home": [
+  "./styles.scss": [
     {
-      "id": "./src/pages/Home/index.js",
-      "name": "./src/pages/Home/index.js",
+      "id": "./src/app/styles.scss",
+      "name": "./src/app/styles.scss",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/pages/Home/Home.js",
-      "name": "./src/pages/Home/Home.js",
+      "id": "./src/components/ErrorDisplay/styles.scss",
+      "name": "./src/components/ErrorDisplay/styles.scss",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/pages/Home/index.js",
-      "name": "./src/pages/Home/index.js",
+      "id": "./src/components/Loading/styles.scss",
+      "name": "./src/components/Loading/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/UserCard/styles.scss",
+      "name": "./src/components/UserCard/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/UserList/styles.scss",
+      "name": "./src/components/UserList/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/pages/Home/styles.scss",
+      "name": "./src/pages/Home/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/pages/NotFound/styles.scss",
+      "name": "./src/pages/NotFound/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/pages/UserInfo/styles.scss",
+      "name": "./src/pages/UserInfo/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/app/styles.scss",
+      "name": "./src/app/styles.scss",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "./src/pages/Home/Home.js",
-      "name": "./src/pages/Home/Home.js",
+      "id": "./src/components/ErrorDisplay/styles.scss",
+      "name": "./src/components/ErrorDisplay/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/Loading/styles.scss",
+      "name": "./src/components/Loading/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/UserCard/styles.scss",
+      "name": "./src/components/UserCard/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/UserList/styles.scss",
+      "name": "./src/components/UserList/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/pages/Home/styles.scss",
+      "name": "./src/pages/Home/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/pages/NotFound/styles.scss",
+      "name": "./src/pages/NotFound/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/pages/UserInfo/styles.scss",
+      "name": "./src/pages/UserInfo/styles.scss",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "../../components": [
+  "./src/client.js": [
     {
-      "id": "./src/components/index.js",
-      "name": "./src/components/index.js",
+      "id": "./src/client.js",
+      "name": "./src/client.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/index.js",
-      "name": "./src/components/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./UserList": [
-    {
-      "id": "./src/components/UserList/index.js",
-      "name": "./src/components/UserList/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/UserList/index.js",
-      "name": "./src/components/UserList/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.function.name": [
-    {
-      "id": "./node_modules/core-js/modules/es6.function.name.js",
-      "name": "./node_modules/core-js/modules/es6.function.name.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.function.name.js",
-      "name": "./node_modules/core-js/modules/es6.function.name.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./UserCard": [
-    {
-      "id": "./src/components/UserCard/index.js",
-      "name": "./src/components/UserCard/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/UserCard/index.js",
-      "name": "./src/components/UserCard/index.js",
+      "id": "./src/client.js",
+      "name": "./src/client.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -4797,252 +4397,98 @@
       "publicPath": "/assets/main.js"
     }
   ],
-  "core-js/modules/es7.symbol.async-iterator": [
+  "./UserCard": [
     {
-      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
-      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "id": "./src/components/UserCard/index.js",
+      "name": "./src/components/UserCard/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
-      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "id": "./src/components/UserCard/index.js",
+      "name": "./src/components/UserCard/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./_wks-define": [
+  "./UserList": [
     {
-      "id": "./node_modules/core-js/modules/_wks-define.js",
-      "name": "./node_modules/core-js/modules/_wks-define.js",
+      "id": "./src/components/UserList/index.js",
+      "name": "./src/components/UserList/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_wks-define.js",
-      "name": "./node_modules/core-js/modules/_wks-define.js",
+      "id": "./src/components/UserList/index.js",
+      "name": "./src/components/UserList/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./_wks-ext": [
+  "../../components": [
     {
-      "id": "./node_modules/core-js/modules/_wks-ext.js",
-      "name": "./node_modules/core-js/modules/_wks-ext.js",
+      "id": "./src/components/index.js",
+      "name": "./src/components/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_wks-ext.js",
-      "name": "./node_modules/core-js/modules/_wks-ext.js",
+      "id": "./src/components/index.js",
+      "name": "./src/components/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "core-js/modules/es6.symbol": [
+  "./default": [
     {
-      "id": "./node_modules/core-js/modules/es6.symbol.js",
-      "name": "./node_modules/core-js/modules/es6.symbol.js",
+      "id": "./src/config/default.js",
+      "name": "./src/config/default.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/es6.symbol.js",
-      "name": "./node_modules/core-js/modules/es6.symbol.js",
+      "id": "./src/config/default.js",
+      "name": "./src/config/default.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./_meta": [
+  "../config": [
     {
-      "id": "./node_modules/core-js/modules/_meta.js",
-      "name": "./node_modules/core-js/modules/_meta.js",
+      "id": "./src/config/index.js",
+      "name": "./src/config/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_meta.js",
-      "name": "./node_modules/core-js/modules/_meta.js",
+      "id": "./src/config/index.js",
+      "name": "./src/config/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
   ],
-  "./_enum-keys": [
+  "./Home": [
     {
-      "id": "./node_modules/core-js/modules/_enum-keys.js",
-      "name": "./node_modules/core-js/modules/_enum-keys.js",
+      "id": "./src/pages/Home/Home.js",
+      "name": "./src/pages/Home/Home.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_enum-keys.js",
-      "name": "./node_modules/core-js/modules/_enum-keys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gops": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gops.js",
-      "name": "./node_modules/core-js/modules/_object-gops.js",
+      "id": "./src/pages/Home/index.js",
+      "name": "./src/pages/Home/index.js",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_object-gops.js",
-      "name": "./node_modules/core-js/modules/_object-gops.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-pie": [
-    {
-      "id": "./node_modules/core-js/modules/_object-pie.js",
-      "name": "./node_modules/core-js/modules/_object-pie.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-pie.js",
-      "name": "./node_modules/core-js/modules/_object-pie.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_is-array": [
-    {
-      "id": "./node_modules/core-js/modules/_is-array.js",
-      "name": "./node_modules/core-js/modules/_is-array.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_is-array.js",
-      "name": "./node_modules/core-js/modules/_is-array.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gopn-ext": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gopn": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn.js",
-      "name": "./node_modules/core-js/modules/_object-gopn.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn.js",
-      "name": "./node_modules/core-js/modules/_object-gopn.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gopd": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gopd.js",
-      "name": "./node_modules/core-js/modules/_object-gopd.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-gopd.js",
-      "name": "./node_modules/core-js/modules/_object-gopd.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.object.set-prototype-of": [
-    {
-      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_set-proto": [
-    {
-      "id": "./node_modules/core-js/modules/_set-proto.js",
-      "name": "./node_modules/core-js/modules/_set-proto.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_set-proto.js",
-      "name": "./node_modules/core-js/modules/_set-proto.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./UserInfo": [
-    {
-      "id": "./src/pages/UserInfo/index.js",
-      "name": "./src/pages/UserInfo/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/pages/UserInfo/UserInfo.js",
-      "name": "./src/pages/UserInfo/UserInfo.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/pages/UserInfo/index.js",
-      "name": "./src/pages/UserInfo/index.js",
+      "id": "./src/pages/Home/Home.js",
+      "name": "./src/pages/Home/Home.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "./src/pages/UserInfo/UserInfo.js",
-      "name": "./src/pages/UserInfo/UserInfo.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.regexp.match": [
-    {
-      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_fix-re-wks": [
-    {
-      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
-      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
-      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "id": "./src/pages/Home/index.js",
+      "name": "./src/pages/Home/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }
@@ -5057,6 +4503,116 @@
     {
       "id": "./src/pages/NotFound/index.js",
       "name": "./src/pages/NotFound/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./UserInfo": [
+    {
+      "id": "./src/pages/UserInfo/UserInfo.js",
+      "name": "./src/pages/UserInfo/UserInfo.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/pages/UserInfo/index.js",
+      "name": "./src/pages/UserInfo/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/pages/UserInfo/UserInfo.js",
+      "name": "./src/pages/UserInfo/UserInfo.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/pages/UserInfo/index.js",
+      "name": "./src/pages/UserInfo/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./pages": [
+    {
+      "id": "./src/pages/index.js",
+      "name": "./src/pages/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/pages/index.js",
+      "name": "./src/pages/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./home": [
+    {
+      "id": "./src/reducers/home.js",
+      "name": "./src/reducers/home.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/reducers/home.js",
+      "name": "./src/reducers/home.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "../reducers": [
+    {
+      "id": "./src/reducers/index.js",
+      "name": "./src/reducers/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/reducers/index.js",
+      "name": "./src/reducers/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./userInfo": [
+    {
+      "id": "./src/reducers/userInfo.js",
+      "name": "./src/reducers/userInfo.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/reducers/userInfo.js",
+      "name": "./src/reducers/userInfo.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./routes": [
+    {
+      "id": "./src/routes.js",
+      "name": "./src/routes.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/routes.js",
+      "name": "./src/routes.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    }
+  ],
+  "./utils/configureStore": [
+    {
+      "id": "./src/utils/configureStore.js",
+      "name": "./src/utils/configureStore.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/utils/configureStore.js",
+      "name": "./src/utils/configureStore.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     }

--- a/public/loadable-assets.json
+++ b/public/loadable-assets.json
@@ -7,55 +7,55 @@
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?1f82",
+      "id": 1,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?23b0",
+      "id": 2,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?4097",
+      "id": 3,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?4fb3",
+      "id": 4,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?7768",
+      "id": 5,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?9b69",
+      "id": 6,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?ae88",
+      "id": 7,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?bb4d",
+      "id": 8,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "?f89f",
+      "id": 9,
       "name": null,
       "file": "main.css",
       "publicPath": "/assets/main.css"
@@ -67,58 +67,118 @@
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?1f82",
+      "id": 1,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?23b0",
+      "id": 2,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?4097",
+      "id": 3,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?4fb3",
+      "id": 4,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?7768",
+      "id": 5,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?9b69",
+      "id": 6,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?ae88",
+      "id": 7,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?bb4d",
+      "id": 8,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "?f89f",
+      "id": 9,
       "name": null,
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": 0,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 1,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 2,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 3,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 4,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 5,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 6,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 7,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 8,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": 9,
+      "name": null,
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "@babel/runtime/helpers/esm/assertThisInitialized": [
@@ -133,6 +193,12 @@
       "name": "./node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "@babel/runtime/helpers/esm/extends": [
@@ -147,6 +213,12 @@
       "name": "./node_modules/@babel/runtime/helpers/esm/extends.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/@babel/runtime/helpers/esm/extends.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/extends.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "@babel/runtime/helpers/esm/inheritsLoose": [
@@ -161,6 +233,12 @@
       "name": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "@babel/runtime/helpers/esm/objectWithoutPropertiesLoose": [
@@ -175,6 +253,12 @@
       "name": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
+      "name": "./node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "ansi-html": [
@@ -189,6 +273,12 @@
       "name": "./node_modules/ansi-html/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/ansi-html/index.js",
+      "name": "./node_modules/ansi-html/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "ansi-regex": [
@@ -203,6 +293,12 @@
       "name": "./node_modules/ansi-regex/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/ansi-regex/index.js",
+      "name": "./node_modules/ansi-regex/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "axios": [
@@ -217,6 +313,12 @@
       "name": "./node_modules/axios/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/index.js",
+      "name": "./node_modules/axios/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./adapters/xhr": [
@@ -231,6 +333,12 @@
       "name": "./node_modules/axios/lib/adapters/xhr.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/adapters/xhr.js",
+      "name": "./node_modules/axios/lib/adapters/xhr.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./lib/axios": [
@@ -245,6 +353,12 @@
       "name": "./node_modules/axios/lib/axios.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/axios.js",
+      "name": "./node_modules/axios/lib/axios.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cancel/Cancel": [
@@ -259,6 +373,12 @@
       "name": "./node_modules/axios/lib/cancel/Cancel.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/cancel/Cancel.js",
+      "name": "./node_modules/axios/lib/cancel/Cancel.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cancel/CancelToken": [
@@ -273,6 +393,12 @@
       "name": "./node_modules/axios/lib/cancel/CancelToken.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/cancel/CancelToken.js",
+      "name": "./node_modules/axios/lib/cancel/CancelToken.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cancel/isCancel": [
@@ -287,6 +413,12 @@
       "name": "./node_modules/axios/lib/cancel/isCancel.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/cancel/isCancel.js",
+      "name": "./node_modules/axios/lib/cancel/isCancel.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./core/Axios": [
@@ -301,6 +433,12 @@
       "name": "./node_modules/axios/lib/core/Axios.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/core/Axios.js",
+      "name": "./node_modules/axios/lib/core/Axios.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./InterceptorManager": [
@@ -315,6 +453,12 @@
       "name": "./node_modules/axios/lib/core/InterceptorManager.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/core/InterceptorManager.js",
+      "name": "./node_modules/axios/lib/core/InterceptorManager.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "../core/createError": [
@@ -329,6 +473,12 @@
       "name": "./node_modules/axios/lib/core/createError.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/core/createError.js",
+      "name": "./node_modules/axios/lib/core/createError.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./dispatchRequest": [
@@ -343,6 +493,12 @@
       "name": "./node_modules/axios/lib/core/dispatchRequest.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/core/dispatchRequest.js",
+      "name": "./node_modules/axios/lib/core/dispatchRequest.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./enhanceError": [
@@ -357,6 +513,12 @@
       "name": "./node_modules/axios/lib/core/enhanceError.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/core/enhanceError.js",
+      "name": "./node_modules/axios/lib/core/enhanceError.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../core/settle": [
@@ -371,6 +533,12 @@
       "name": "./node_modules/axios/lib/core/settle.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/core/settle.js",
+      "name": "./node_modules/axios/lib/core/settle.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./transformData": [
@@ -385,6 +553,12 @@
       "name": "./node_modules/axios/lib/core/transformData.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/core/transformData.js",
+      "name": "./node_modules/axios/lib/core/transformData.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./defaults": [
@@ -399,6 +573,12 @@
       "name": "./node_modules/axios/lib/defaults.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/defaults.js",
+      "name": "./node_modules/axios/lib/defaults.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./helpers/bind": [
@@ -413,6 +593,12 @@
       "name": "./node_modules/axios/lib/helpers/bind.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/bind.js",
+      "name": "./node_modules/axios/lib/helpers/bind.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../helpers/btoa": [
@@ -427,6 +613,12 @@
       "name": "./node_modules/axios/lib/helpers/btoa.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/btoa.js",
+      "name": "./node_modules/axios/lib/helpers/btoa.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../helpers/buildURL": [
@@ -441,6 +633,12 @@
       "name": "./node_modules/axios/lib/helpers/buildURL.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/buildURL.js",
+      "name": "./node_modules/axios/lib/helpers/buildURL.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../helpers/combineURLs": [
@@ -455,6 +653,12 @@
       "name": "./node_modules/axios/lib/helpers/combineURLs.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/combineURLs.js",
+      "name": "./node_modules/axios/lib/helpers/combineURLs.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../helpers/cookies": [
@@ -469,6 +673,12 @@
       "name": "./node_modules/axios/lib/helpers/cookies.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/cookies.js",
+      "name": "./node_modules/axios/lib/helpers/cookies.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../helpers/isAbsoluteURL": [
@@ -483,6 +693,12 @@
       "name": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
+      "name": "./node_modules/axios/lib/helpers/isAbsoluteURL.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../helpers/isURLSameOrigin": [
@@ -497,6 +713,12 @@
       "name": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
+      "name": "./node_modules/axios/lib/helpers/isURLSameOrigin.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./helpers/normalizeHeaderName": [
@@ -511,6 +733,12 @@
       "name": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
+      "name": "./node_modules/axios/lib/helpers/normalizeHeaderName.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../helpers/parseHeaders": [
@@ -525,6 +753,12 @@
       "name": "./node_modules/axios/lib/helpers/parseHeaders.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/parseHeaders.js",
+      "name": "./node_modules/axios/lib/helpers/parseHeaders.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./helpers/spread": [
@@ -539,6 +773,12 @@
       "name": "./node_modules/axios/lib/helpers/spread.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/helpers/spread.js",
+      "name": "./node_modules/axios/lib/helpers/spread.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./utils": [
@@ -553,6 +793,12 @@
       "name": "./node_modules/axios/lib/utils.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/axios/lib/utils.js",
+      "name": "./node_modules/axios/lib/utils.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./ConnectedRouter": [
@@ -567,6 +813,12 @@
       "name": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
+      "name": "./node_modules/connected-react-router/esm/ConnectedRouter.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./actions": [
@@ -593,6 +845,18 @@
       "name": "./src/actions/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/actions.js",
+      "name": "./node_modules/connected-react-router/esm/actions.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/actions/index.js",
+      "name": "./src/actions/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "connected-react-router": [
@@ -607,6 +871,12 @@
       "name": "./node_modules/connected-react-router/esm/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/index.js",
+      "name": "./node_modules/connected-react-router/esm/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./middleware": [
@@ -621,6 +891,12 @@
       "name": "./node_modules/connected-react-router/esm/middleware.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/middleware.js",
+      "name": "./node_modules/connected-react-router/esm/middleware.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./reducer": [
@@ -635,6 +911,12 @@
       "name": "./node_modules/connected-react-router/esm/reducer.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/reducer.js",
+      "name": "./node_modules/connected-react-router/esm/reducer.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./selectors": [
@@ -649,6 +931,12 @@
       "name": "./node_modules/connected-react-router/esm/selectors.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/selectors.js",
+      "name": "./node_modules/connected-react-router/esm/selectors.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./getIn": [
@@ -663,6 +951,12 @@
       "name": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
+      "name": "./node_modules/connected-react-router/esm/structure/plain/getIn.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./structure/plain": [
@@ -677,6 +971,12 @@
       "name": "./node_modules/connected-react-router/esm/structure/plain/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/connected-react-router/esm/structure/plain/index.js",
+      "name": "./node_modules/connected-react-router/esm/structure/plain/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_a-function": [
@@ -691,6 +991,12 @@
       "name": "./node_modules/core-js/modules/_a-function.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_a-function.js",
+      "name": "./node_modules/core-js/modules/_a-function.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_add-to-unscopables": [
@@ -705,20 +1011,12 @@
       "name": "./node_modules/core-js/modules/_add-to-unscopables.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_advance-string-index": [
-    {
-      "id": "./node_modules/core-js/modules/_advance-string-index.js",
-      "name": "./node_modules/core-js/modules/_advance-string-index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_advance-string-index.js",
-      "name": "./node_modules/core-js/modules/_advance-string-index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_add-to-unscopables.js",
+      "name": "./node_modules/core-js/modules/_add-to-unscopables.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_an-instance": [
@@ -733,6 +1031,12 @@
       "name": "./node_modules/core-js/modules/_an-instance.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_an-instance.js",
+      "name": "./node_modules/core-js/modules/_an-instance.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_an-object": [
@@ -747,6 +1051,12 @@
       "name": "./node_modules/core-js/modules/_an-object.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_an-object.js",
+      "name": "./node_modules/core-js/modules/_an-object.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_array-includes": [
@@ -761,6 +1071,12 @@
       "name": "./node_modules/core-js/modules/_array-includes.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_array-includes.js",
+      "name": "./node_modules/core-js/modules/_array-includes.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_classof": [
@@ -775,6 +1091,12 @@
       "name": "./node_modules/core-js/modules/_classof.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_classof.js",
+      "name": "./node_modules/core-js/modules/_classof.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_cof": [
@@ -789,6 +1111,12 @@
       "name": "./node_modules/core-js/modules/_cof.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_cof.js",
+      "name": "./node_modules/core-js/modules/_cof.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_core": [
@@ -803,6 +1131,12 @@
       "name": "./node_modules/core-js/modules/_core.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_core.js",
+      "name": "./node_modules/core-js/modules/_core.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_ctx": [
@@ -817,6 +1151,12 @@
       "name": "./node_modules/core-js/modules/_ctx.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_ctx.js",
+      "name": "./node_modules/core-js/modules/_ctx.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_defined": [
@@ -831,6 +1171,12 @@
       "name": "./node_modules/core-js/modules/_defined.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_defined.js",
+      "name": "./node_modules/core-js/modules/_defined.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_descriptors": [
@@ -845,6 +1191,12 @@
       "name": "./node_modules/core-js/modules/_descriptors.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_descriptors.js",
+      "name": "./node_modules/core-js/modules/_descriptors.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_dom-create": [
@@ -859,6 +1211,12 @@
       "name": "./node_modules/core-js/modules/_dom-create.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_dom-create.js",
+      "name": "./node_modules/core-js/modules/_dom-create.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_enum-bug-keys": [
@@ -873,20 +1231,12 @@
       "name": "./node_modules/core-js/modules/_enum-bug-keys.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_enum-keys": [
-    {
-      "id": "./node_modules/core-js/modules/_enum-keys.js",
-      "name": "./node_modules/core-js/modules/_enum-keys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_enum-keys.js",
-      "name": "./node_modules/core-js/modules/_enum-keys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_enum-bug-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-bug-keys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_export": [
@@ -901,6 +1251,12 @@
       "name": "./node_modules/core-js/modules/_export.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_export.js",
+      "name": "./node_modules/core-js/modules/_export.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_fails": [
@@ -915,48 +1271,12 @@
       "name": "./node_modules/core-js/modules/_fails.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_fix-re-wks": [
-    {
-      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
-      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
-      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_flags": [
-    {
-      "id": "./node_modules/core-js/modules/_flags.js",
-      "name": "./node_modules/core-js/modules/_flags.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_flags.js",
-      "name": "./node_modules/core-js/modules/_flags.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_for-of": [
-    {
-      "id": "./node_modules/core-js/modules/_for-of.js",
-      "name": "./node_modules/core-js/modules/_for-of.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_for-of.js",
-      "name": "./node_modules/core-js/modules/_for-of.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_fails.js",
+      "name": "./node_modules/core-js/modules/_fails.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_function-to-string": [
@@ -971,6 +1291,12 @@
       "name": "./node_modules/core-js/modules/_function-to-string.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_function-to-string.js",
+      "name": "./node_modules/core-js/modules/_function-to-string.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_global": [
@@ -985,6 +1311,12 @@
       "name": "./node_modules/core-js/modules/_global.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_global.js",
+      "name": "./node_modules/core-js/modules/_global.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_has": [
@@ -999,6 +1331,12 @@
       "name": "./node_modules/core-js/modules/_has.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_has.js",
+      "name": "./node_modules/core-js/modules/_has.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_hide": [
@@ -1013,6 +1351,12 @@
       "name": "./node_modules/core-js/modules/_hide.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_hide.js",
+      "name": "./node_modules/core-js/modules/_hide.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_html": [
@@ -1027,6 +1371,12 @@
       "name": "./node_modules/core-js/modules/_html.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_html.js",
+      "name": "./node_modules/core-js/modules/_html.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_ie8-dom-define": [
@@ -1041,20 +1391,12 @@
       "name": "./node_modules/core-js/modules/_ie8-dom-define.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_invoke": [
-    {
-      "id": "./node_modules/core-js/modules/_invoke.js",
-      "name": "./node_modules/core-js/modules/_invoke.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_invoke.js",
-      "name": "./node_modules/core-js/modules/_invoke.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_ie8-dom-define.js",
+      "name": "./node_modules/core-js/modules/_ie8-dom-define.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_iobject": [
@@ -1069,34 +1411,12 @@
       "name": "./node_modules/core-js/modules/_iobject.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_is-array-iter": [
-    {
-      "id": "./node_modules/core-js/modules/_is-array-iter.js",
-      "name": "./node_modules/core-js/modules/_is-array-iter.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_is-array-iter.js",
-      "name": "./node_modules/core-js/modules/_is-array-iter.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_is-array": [
-    {
-      "id": "./node_modules/core-js/modules/_is-array.js",
-      "name": "./node_modules/core-js/modules/_is-array.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_is-array.js",
-      "name": "./node_modules/core-js/modules/_is-array.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_iobject.js",
+      "name": "./node_modules/core-js/modules/_iobject.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_is-object": [
@@ -1111,20 +1431,12 @@
       "name": "./node_modules/core-js/modules/_is-object.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iter-call": [
-    {
-      "id": "./node_modules/core-js/modules/_iter-call.js",
-      "name": "./node_modules/core-js/modules/_iter-call.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_iter-call.js",
-      "name": "./node_modules/core-js/modules/_iter-call.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_is-object.js",
+      "name": "./node_modules/core-js/modules/_is-object.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_iter-create": [
@@ -1139,6 +1451,12 @@
       "name": "./node_modules/core-js/modules/_iter-create.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-create.js",
+      "name": "./node_modules/core-js/modules/_iter-create.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_iter-define": [
@@ -1153,20 +1471,12 @@
       "name": "./node_modules/core-js/modules/_iter-define.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_iter-detect": [
-    {
-      "id": "./node_modules/core-js/modules/_iter-detect.js",
-      "name": "./node_modules/core-js/modules/_iter-detect.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_iter-detect.js",
-      "name": "./node_modules/core-js/modules/_iter-detect.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_iter-define.js",
+      "name": "./node_modules/core-js/modules/_iter-define.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_iter-step": [
@@ -1181,6 +1491,12 @@
       "name": "./node_modules/core-js/modules/_iter-step.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-step.js",
+      "name": "./node_modules/core-js/modules/_iter-step.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_iterators": [
@@ -1195,6 +1511,12 @@
       "name": "./node_modules/core-js/modules/_iterators.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iterators.js",
+      "name": "./node_modules/core-js/modules/_iterators.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_library": [
@@ -1209,48 +1531,12 @@
       "name": "./node_modules/core-js/modules/_library.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_meta": [
-    {
-      "id": "./node_modules/core-js/modules/_meta.js",
-      "name": "./node_modules/core-js/modules/_meta.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_meta.js",
-      "name": "./node_modules/core-js/modules/_meta.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_microtask": [
-    {
-      "id": "./node_modules/core-js/modules/_microtask.js",
-      "name": "./node_modules/core-js/modules/_microtask.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_microtask.js",
-      "name": "./node_modules/core-js/modules/_microtask.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_new-promise-capability": [
-    {
-      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_library.js",
+      "name": "./node_modules/core-js/modules/_library.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_object-create": [
@@ -1265,6 +1551,12 @@
       "name": "./node_modules/core-js/modules/_object-create.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-create.js",
+      "name": "./node_modules/core-js/modules/_object-create.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_object-dp": [
@@ -1279,6 +1571,12 @@
       "name": "./node_modules/core-js/modules/_object-dp.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-dp.js",
+      "name": "./node_modules/core-js/modules/_object-dp.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_object-dps": [
@@ -1293,62 +1591,12 @@
       "name": "./node_modules/core-js/modules/_object-dps.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gopd": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gopd.js",
-      "name": "./node_modules/core-js/modules/_object-gopd.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_object-gopd.js",
-      "name": "./node_modules/core-js/modules/_object-gopd.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gopn-ext": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gopn": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn.js",
-      "name": "./node_modules/core-js/modules/_object-gopn.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-gopn.js",
-      "name": "./node_modules/core-js/modules/_object-gopn.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-gops": [
-    {
-      "id": "./node_modules/core-js/modules/_object-gops.js",
-      "name": "./node_modules/core-js/modules/_object-gops.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_object-gops.js",
-      "name": "./node_modules/core-js/modules/_object-gops.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_object-dps.js",
+      "name": "./node_modules/core-js/modules/_object-dps.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_object-gpo": [
@@ -1363,6 +1611,12 @@
       "name": "./node_modules/core-js/modules/_object-gpo.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gpo.js",
+      "name": "./node_modules/core-js/modules/_object-gpo.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_object-keys-internal": [
@@ -1377,6 +1631,12 @@
       "name": "./node_modules/core-js/modules/_object-keys-internal.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-keys-internal.js",
+      "name": "./node_modules/core-js/modules/_object-keys-internal.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_object-keys": [
@@ -1391,20 +1651,12 @@
       "name": "./node_modules/core-js/modules/_object-keys.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_object-pie": [
-    {
-      "id": "./node_modules/core-js/modules/_object-pie.js",
-      "name": "./node_modules/core-js/modules/_object-pie.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_object-pie.js",
-      "name": "./node_modules/core-js/modules/_object-pie.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_object-keys.js",
+      "name": "./node_modules/core-js/modules/_object-keys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_object-sap": [
@@ -1419,34 +1671,12 @@
       "name": "./node_modules/core-js/modules/_object-sap.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_perform": [
-    {
-      "id": "./node_modules/core-js/modules/_perform.js",
-      "name": "./node_modules/core-js/modules/_perform.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_perform.js",
-      "name": "./node_modules/core-js/modules/_perform.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_promise-resolve": [
-    {
-      "id": "./node_modules/core-js/modules/_promise-resolve.js",
-      "name": "./node_modules/core-js/modules/_promise-resolve.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_promise-resolve.js",
-      "name": "./node_modules/core-js/modules/_promise-resolve.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_object-sap.js",
+      "name": "./node_modules/core-js/modules/_object-sap.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_property-desc": [
@@ -1461,20 +1691,12 @@
       "name": "./node_modules/core-js/modules/_property-desc.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_redefine-all": [
-    {
-      "id": "./node_modules/core-js/modules/_redefine-all.js",
-      "name": "./node_modules/core-js/modules/_redefine-all.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_redefine-all.js",
-      "name": "./node_modules/core-js/modules/_redefine-all.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_property-desc.js",
+      "name": "./node_modules/core-js/modules/_property-desc.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_redefine": [
@@ -1489,62 +1711,12 @@
       "name": "./node_modules/core-js/modules/_redefine.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_regexp-exec-abstract": [
-    {
-      "id": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
-      "name": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
-      "name": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_regexp-exec": [
-    {
-      "id": "./node_modules/core-js/modules/_regexp-exec.js",
-      "name": "./node_modules/core-js/modules/_regexp-exec.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_regexp-exec.js",
-      "name": "./node_modules/core-js/modules/_regexp-exec.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_set-proto": [
-    {
-      "id": "./node_modules/core-js/modules/_set-proto.js",
-      "name": "./node_modules/core-js/modules/_set-proto.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_set-proto.js",
-      "name": "./node_modules/core-js/modules/_set-proto.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_set-species": [
-    {
-      "id": "./node_modules/core-js/modules/_set-species.js",
-      "name": "./node_modules/core-js/modules/_set-species.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_set-species.js",
-      "name": "./node_modules/core-js/modules/_set-species.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_redefine.js",
+      "name": "./node_modules/core-js/modules/_redefine.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_set-to-string-tag": [
@@ -1559,6 +1731,12 @@
       "name": "./node_modules/core-js/modules/_set-to-string-tag.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-to-string-tag.js",
+      "name": "./node_modules/core-js/modules/_set-to-string-tag.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_shared-key": [
@@ -1573,6 +1751,12 @@
       "name": "./node_modules/core-js/modules/_shared-key.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_shared-key.js",
+      "name": "./node_modules/core-js/modules/_shared-key.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_shared": [
@@ -1587,48 +1771,12 @@
       "name": "./node_modules/core-js/modules/_shared.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_species-constructor": [
-    {
-      "id": "./node_modules/core-js/modules/_species-constructor.js",
-      "name": "./node_modules/core-js/modules/_species-constructor.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_species-constructor.js",
-      "name": "./node_modules/core-js/modules/_species-constructor.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_string-at": [
-    {
-      "id": "./node_modules/core-js/modules/_string-at.js",
-      "name": "./node_modules/core-js/modules/_string-at.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_string-at.js",
-      "name": "./node_modules/core-js/modules/_string-at.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_task": [
-    {
-      "id": "./node_modules/core-js/modules/_task.js",
-      "name": "./node_modules/core-js/modules/_task.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_task.js",
-      "name": "./node_modules/core-js/modules/_task.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_shared.js",
+      "name": "./node_modules/core-js/modules/_shared.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_to-absolute-index": [
@@ -1643,6 +1791,12 @@
       "name": "./node_modules/core-js/modules/_to-absolute-index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-absolute-index.js",
+      "name": "./node_modules/core-js/modules/_to-absolute-index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_to-integer": [
@@ -1657,6 +1811,12 @@
       "name": "./node_modules/core-js/modules/_to-integer.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-integer.js",
+      "name": "./node_modules/core-js/modules/_to-integer.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_to-iobject": [
@@ -1671,6 +1831,12 @@
       "name": "./node_modules/core-js/modules/_to-iobject.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-iobject.js",
+      "name": "./node_modules/core-js/modules/_to-iobject.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_to-length": [
@@ -1685,6 +1851,12 @@
       "name": "./node_modules/core-js/modules/_to-length.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-length.js",
+      "name": "./node_modules/core-js/modules/_to-length.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_to-object": [
@@ -1699,6 +1871,12 @@
       "name": "./node_modules/core-js/modules/_to-object.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-object.js",
+      "name": "./node_modules/core-js/modules/_to-object.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_to-primitive": [
@@ -1713,6 +1891,12 @@
       "name": "./node_modules/core-js/modules/_to-primitive.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_to-primitive.js",
+      "name": "./node_modules/core-js/modules/_to-primitive.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_uid": [
@@ -1727,48 +1911,12 @@
       "name": "./node_modules/core-js/modules/_uid.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_user-agent": [
-    {
-      "id": "./node_modules/core-js/modules/_user-agent.js",
-      "name": "./node_modules/core-js/modules/_user-agent.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/_user-agent.js",
-      "name": "./node_modules/core-js/modules/_user-agent.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_wks-define": [
-    {
-      "id": "./node_modules/core-js/modules/_wks-define.js",
-      "name": "./node_modules/core-js/modules/_wks-define.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_wks-define.js",
-      "name": "./node_modules/core-js/modules/_wks-define.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_wks-ext": [
-    {
-      "id": "./node_modules/core-js/modules/_wks-ext.js",
-      "name": "./node_modules/core-js/modules/_wks-ext.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/_wks-ext.js",
-      "name": "./node_modules/core-js/modules/_wks-ext.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_uid.js",
+      "name": "./node_modules/core-js/modules/_uid.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_wks": [
@@ -1783,20 +1931,12 @@
       "name": "./node_modules/core-js/modules/_wks.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./core.get-iterator-method": [
-    {
-      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/_wks.js",
+      "name": "./node_modules/core-js/modules/_wks.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "core-js/modules/es6.array.iterator": [
@@ -1811,6 +1951,12 @@
       "name": "./node_modules/core-js/modules/es6.array.iterator.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.array.iterator.js",
+      "name": "./node_modules/core-js/modules/es6.array.iterator.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "core-js/modules/es6.function.name": [
@@ -1825,6 +1971,12 @@
       "name": "./node_modules/core-js/modules/es6.function.name.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.function.name.js",
+      "name": "./node_modules/core-js/modules/es6.function.name.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "core-js/modules/es6.object.keys": [
@@ -1839,90 +1991,12 @@
       "name": "./node_modules/core-js/modules/es6.object.keys.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.object.set-prototype-of": [
-    {
-      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.promise": [
-    {
-      "id": "./node_modules/core-js/modules/es6.promise.js",
-      "name": "./node_modules/core-js/modules/es6.promise.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.promise.js",
-      "name": "./node_modules/core-js/modules/es6.promise.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./es6.regexp.exec": [
-    {
-      "id": "./node_modules/core-js/modules/es6.regexp.exec.js",
-      "name": "./node_modules/core-js/modules/es6.regexp.exec.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.regexp.exec.js",
-      "name": "./node_modules/core-js/modules/es6.regexp.exec.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.regexp.match": [
-    {
-      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es6.symbol": [
-    {
-      "id": "./node_modules/core-js/modules/es6.symbol.js",
-      "name": "./node_modules/core-js/modules/es6.symbol.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es6.symbol.js",
-      "name": "./node_modules/core-js/modules/es6.symbol.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "core-js/modules/es7.symbol.async-iterator": [
-    {
-      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
-      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
-      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/core-js/modules/es6.object.keys.js",
+      "name": "./node_modules/core-js/modules/es6.object.keys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "core-js/modules/web.dom.iterable": [
@@ -1937,6 +2011,12 @@
       "name": "./node_modules/core-js/modules/web.dom.iterable.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/web.dom.iterable.js",
+      "name": "./node_modules/core-js/modules/web.dom.iterable.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./implementation": [
@@ -1951,6 +2031,12 @@
       "name": "./node_modules/create-react-context/lib/implementation.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/create-react-context/lib/implementation.js",
+      "name": "./node_modules/create-react-context/lib/implementation.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "create-react-context": [
@@ -1965,6 +2051,12 @@
       "name": "./node_modules/create-react-context/lib/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/create-react-context/lib/index.js",
+      "name": "./node_modules/create-react-context/lib/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "!../css-hot-loader/hotModuleReplacement.js": [
@@ -1979,6 +2071,12 @@
       "name": "./node_modules/css-hot-loader/hotModuleReplacement.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "name": "./node_modules/css-hot-loader/hotModuleReplacement.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "deep-equal": [
@@ -1993,6 +2091,12 @@
       "name": "./node_modules/deep-equal/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/deep-equal/index.js",
+      "name": "./node_modules/deep-equal/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./lib/is_arguments.js": [
@@ -2007,6 +2111,12 @@
       "name": "./node_modules/deep-equal/lib/is_arguments.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/deep-equal/lib/is_arguments.js",
+      "name": "./node_modules/deep-equal/lib/is_arguments.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./lib/keys.js": [
@@ -2021,6 +2131,12 @@
       "name": "./node_modules/deep-equal/lib/keys.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/deep-equal/lib/keys.js",
+      "name": "./node_modules/deep-equal/lib/keys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "exenv": [
@@ -2035,6 +2151,12 @@
       "name": "./node_modules/exenv/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/exenv/index.js",
+      "name": "./node_modules/exenv/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "fast-levenshtein": [
@@ -2049,6 +2171,12 @@
       "name": "./node_modules/fast-levenshtein/levenshtein.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/fast-levenshtein/levenshtein.js",
+      "name": "./node_modules/fast-levenshtein/levenshtein.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./emptyFunction": [
@@ -2063,6 +2191,12 @@
       "name": "./node_modules/fbjs/lib/emptyFunction.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/fbjs/lib/emptyFunction.js",
+      "name": "./node_modules/fbjs/lib/emptyFunction.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "fbjs/lib/warning": [
@@ -2077,6 +2211,12 @@
       "name": "./node_modules/fbjs/lib/warning.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/fbjs/lib/warning.js",
+      "name": "./node_modules/fbjs/lib/warning.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "gud": [
@@ -2091,6 +2231,12 @@
       "name": "./node_modules/gud/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/gud/index.js",
+      "name": "./node_modules/gud/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./DOMUtils": [
@@ -2105,6 +2251,12 @@
       "name": "./node_modules/history/es/DOMUtils.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/DOMUtils.js",
+      "name": "./node_modules/history/es/DOMUtils.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./LocationUtils": [
@@ -2119,6 +2271,12 @@
       "name": "./node_modules/history/es/LocationUtils.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/LocationUtils.js",
+      "name": "./node_modules/history/es/LocationUtils.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./PathUtils": [
@@ -2133,6 +2291,12 @@
       "name": "./node_modules/history/es/PathUtils.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/PathUtils.js",
+      "name": "./node_modules/history/es/PathUtils.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./createBrowserHistory": [
@@ -2147,6 +2311,12 @@
       "name": "./node_modules/history/es/createBrowserHistory.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/createBrowserHistory.js",
+      "name": "./node_modules/history/es/createBrowserHistory.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./createHashHistory": [
@@ -2161,6 +2331,12 @@
       "name": "./node_modules/history/es/createHashHistory.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/createHashHistory.js",
+      "name": "./node_modules/history/es/createHashHistory.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./createMemoryHistory": [
@@ -2175,6 +2351,12 @@
       "name": "./node_modules/history/es/createMemoryHistory.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/createMemoryHistory.js",
+      "name": "./node_modules/history/es/createMemoryHistory.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./createTransitionManager": [
@@ -2189,6 +2371,12 @@
       "name": "./node_modules/history/es/createTransitionManager.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/createTransitionManager.js",
+      "name": "./node_modules/history/es/createTransitionManager.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "history": [
@@ -2227,6 +2415,24 @@
       "name": "./node_modules/react-router/node_modules/history/esm/history.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/history/es/index.js",
+      "name": "./node_modules/history/es/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
+      "name": "./node_modules/react-router-dom/node_modules/history/esm/history.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./node_modules/react-router/node_modules/history/esm/history.js",
+      "name": "./node_modules/react-router/node_modules/history/esm/history.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "hoist-non-react-statics": [
@@ -2253,6 +2459,18 @@
       "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "name": "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "name": "./node_modules/react-redux/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "html-entities": [
@@ -2267,6 +2485,12 @@
       "name": "./node_modules/html-entities/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/html-entities/index.js",
+      "name": "./node_modules/html-entities/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./lib/html4-entities.js": [
@@ -2281,6 +2505,12 @@
       "name": "./node_modules/html-entities/lib/html4-entities.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/html-entities/lib/html4-entities.js",
+      "name": "./node_modules/html-entities/lib/html4-entities.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./lib/html5-entities.js": [
@@ -2295,6 +2525,12 @@
       "name": "./node_modules/html-entities/lib/html5-entities.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/html-entities/lib/html5-entities.js",
+      "name": "./node_modules/html-entities/lib/html5-entities.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./lib/xml-entities.js": [
@@ -2309,6 +2545,12 @@
       "name": "./node_modules/html-entities/lib/xml-entities.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/html-entities/lib/xml-entities.js",
+      "name": "./node_modules/html-entities/lib/xml-entities.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "invariant": [
@@ -2323,20 +2565,12 @@
       "name": "./node_modules/invariant/browser.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "is-buffer": [
-    {
-      "id": "./node_modules/is-buffer/index.js",
-      "name": "./node_modules/is-buffer/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/is-buffer/index.js",
-      "name": "./node_modules/is-buffer/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/invariant/browser.js",
+      "name": "./node_modules/invariant/browser.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "is-plain-obj": [
@@ -2351,6 +2585,12 @@
       "name": "./node_modules/is-plain-obj/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/is-plain-obj/index.js",
+      "name": "./node_modules/is-plain-obj/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "lodash.merge": [
@@ -2365,6 +2605,12 @@
       "name": "./node_modules/lodash.merge/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash.merge/index.js",
+      "name": "./node_modules/lodash.merge/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_Symbol": [
@@ -2379,34 +2625,12 @@
       "name": "./node_modules/lodash/_Symbol.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_apply": [
-    {
-      "id": "./node_modules/lodash/_apply.js",
-      "name": "./node_modules/lodash/_apply.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/_apply.js",
-      "name": "./node_modules/lodash/_apply.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_arrayLikeKeys": [
-    {
-      "id": "./node_modules/lodash/_arrayLikeKeys.js",
-      "name": "./node_modules/lodash/_arrayLikeKeys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_arrayLikeKeys.js",
-      "name": "./node_modules/lodash/_arrayLikeKeys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/_Symbol.js",
+      "name": "./node_modules/lodash/_Symbol.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_assignValue": [
@@ -2421,6 +2645,12 @@
       "name": "./node_modules/lodash/_assignValue.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_assignValue.js",
+      "name": "./node_modules/lodash/_assignValue.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_baseAssignValue": [
@@ -2435,6 +2665,12 @@
       "name": "./node_modules/lodash/_baseAssignValue.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseAssignValue.js",
+      "name": "./node_modules/lodash/_baseAssignValue.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_baseGetTag": [
@@ -2449,20 +2685,12 @@
       "name": "./node_modules/lodash/_baseGetTag.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseIsArguments": [
-    {
-      "id": "./node_modules/lodash/_baseIsArguments.js",
-      "name": "./node_modules/lodash/_baseIsArguments.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/_baseIsArguments.js",
-      "name": "./node_modules/lodash/_baseIsArguments.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/_baseGetTag.js",
+      "name": "./node_modules/lodash/_baseGetTag.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_baseIsNative": [
@@ -2477,132 +2705,12 @@
       "name": "./node_modules/lodash/_baseIsNative.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseIsTypedArray": [
-    {
-      "id": "./node_modules/lodash/_baseIsTypedArray.js",
-      "name": "./node_modules/lodash/_baseIsTypedArray.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/_baseIsTypedArray.js",
-      "name": "./node_modules/lodash/_baseIsTypedArray.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseKeys": [
-    {
-      "id": "./node_modules/lodash/_baseKeys.js",
-      "name": "./node_modules/lodash/_baseKeys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseKeys.js",
-      "name": "./node_modules/lodash/_baseKeys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseRest": [
-    {
-      "id": "./node_modules/lodash/_baseRest.js",
-      "name": "./node_modules/lodash/_baseRest.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseRest.js",
-      "name": "./node_modules/lodash/_baseRest.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseSetToString": [
-    {
-      "id": "./node_modules/lodash/_baseSetToString.js",
-      "name": "./node_modules/lodash/_baseSetToString.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseSetToString.js",
-      "name": "./node_modules/lodash/_baseSetToString.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseTimes": [
-    {
-      "id": "./node_modules/lodash/_baseTimes.js",
-      "name": "./node_modules/lodash/_baseTimes.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseTimes.js",
-      "name": "./node_modules/lodash/_baseTimes.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_baseUnary": [
-    {
-      "id": "./node_modules/lodash/_baseUnary.js",
-      "name": "./node_modules/lodash/_baseUnary.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_baseUnary.js",
-      "name": "./node_modules/lodash/_baseUnary.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_copyObject": [
-    {
-      "id": "./node_modules/lodash/_copyObject.js",
-      "name": "./node_modules/lodash/_copyObject.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_copyObject.js",
-      "name": "./node_modules/lodash/_copyObject.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_coreJsData": [
-    {
-      "id": "./node_modules/lodash/_coreJsData.js",
-      "name": "./node_modules/lodash/_coreJsData.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_coreJsData.js",
-      "name": "./node_modules/lodash/_coreJsData.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_createAssigner": [
-    {
-      "id": "./node_modules/lodash/_createAssigner.js",
-      "name": "./node_modules/lodash/_createAssigner.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_createAssigner.js",
-      "name": "./node_modules/lodash/_createAssigner.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/_baseIsNative.js",
+      "name": "./node_modules/lodash/_baseIsNative.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_defineProperty": [
@@ -2617,6 +2725,12 @@
       "name": "./node_modules/lodash/_defineProperty.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_defineProperty.js",
+      "name": "./node_modules/lodash/_defineProperty.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_freeGlobal": [
@@ -2631,6 +2745,12 @@
       "name": "./node_modules/lodash/_freeGlobal.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_freeGlobal.js",
+      "name": "./node_modules/lodash/_freeGlobal.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_getNative": [
@@ -2645,6 +2765,12 @@
       "name": "./node_modules/lodash/_getNative.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_getNative.js",
+      "name": "./node_modules/lodash/_getNative.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_getRawTag": [
@@ -2659,104 +2785,12 @@
       "name": "./node_modules/lodash/_getRawTag.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_getValue": [
-    {
-      "id": "./node_modules/lodash/_getValue.js",
-      "name": "./node_modules/lodash/_getValue.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/_getValue.js",
-      "name": "./node_modules/lodash/_getValue.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isIndex": [
-    {
-      "id": "./node_modules/lodash/_isIndex.js",
-      "name": "./node_modules/lodash/_isIndex.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isIndex.js",
-      "name": "./node_modules/lodash/_isIndex.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isIterateeCall": [
-    {
-      "id": "./node_modules/lodash/_isIterateeCall.js",
-      "name": "./node_modules/lodash/_isIterateeCall.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isIterateeCall.js",
-      "name": "./node_modules/lodash/_isIterateeCall.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isMasked": [
-    {
-      "id": "./node_modules/lodash/_isMasked.js",
-      "name": "./node_modules/lodash/_isMasked.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isMasked.js",
-      "name": "./node_modules/lodash/_isMasked.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_isPrototype": [
-    {
-      "id": "./node_modules/lodash/_isPrototype.js",
-      "name": "./node_modules/lodash/_isPrototype.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_isPrototype.js",
-      "name": "./node_modules/lodash/_isPrototype.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_nativeKeys": [
-    {
-      "id": "./node_modules/lodash/_nativeKeys.js",
-      "name": "./node_modules/lodash/_nativeKeys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_nativeKeys.js",
-      "name": "./node_modules/lodash/_nativeKeys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_nodeUtil": [
-    {
-      "id": "./node_modules/lodash/_nodeUtil.js",
-      "name": "./node_modules/lodash/_nodeUtil.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_nodeUtil.js",
-      "name": "./node_modules/lodash/_nodeUtil.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/_getRawTag.js",
+      "name": "./node_modules/lodash/_getRawTag.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_objectToString": [
@@ -2771,34 +2805,12 @@
       "name": "./node_modules/lodash/_objectToString.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_overArg": [
-    {
-      "id": "./node_modules/lodash/_overArg.js",
-      "name": "./node_modules/lodash/_overArg.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/_overArg.js",
-      "name": "./node_modules/lodash/_overArg.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_overRest": [
-    {
-      "id": "./node_modules/lodash/_overRest.js",
-      "name": "./node_modules/lodash/_overRest.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_overRest.js",
-      "name": "./node_modules/lodash/_overRest.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/_objectToString.js",
+      "name": "./node_modules/lodash/_objectToString.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./_root": [
@@ -2813,48 +2825,12 @@
       "name": "./node_modules/lodash/_root.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_setToString": [
-    {
-      "id": "./node_modules/lodash/_setToString.js",
-      "name": "./node_modules/lodash/_setToString.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/_setToString.js",
-      "name": "./node_modules/lodash/_setToString.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_shortOut": [
-    {
-      "id": "./node_modules/lodash/_shortOut.js",
-      "name": "./node_modules/lodash/_shortOut.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_shortOut.js",
-      "name": "./node_modules/lodash/_shortOut.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./_toSource": [
-    {
-      "id": "./node_modules/lodash/_toSource.js",
-      "name": "./node_modules/lodash/_toSource.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/_toSource.js",
-      "name": "./node_modules/lodash/_toSource.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/_root.js",
+      "name": "./node_modules/lodash/_root.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "lodash/assign": [
@@ -2869,20 +2845,12 @@
       "name": "./node_modules/lodash/assign.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./constant": [
-    {
-      "id": "./node_modules/lodash/constant.js",
-      "name": "./node_modules/lodash/constant.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/constant.js",
-      "name": "./node_modules/lodash/constant.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/assign.js",
+      "name": "./node_modules/lodash/assign.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "lodash/debounce": [
@@ -2897,90 +2865,12 @@
       "name": "./node_modules/lodash/debounce.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./eq": [
-    {
-      "id": "./node_modules/lodash/eq.js",
-      "name": "./node_modules/lodash/eq.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/eq.js",
-      "name": "./node_modules/lodash/eq.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./identity": [
-    {
-      "id": "./node_modules/lodash/identity.js",
-      "name": "./node_modules/lodash/identity.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/identity.js",
-      "name": "./node_modules/lodash/identity.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isArguments": [
-    {
-      "id": "./node_modules/lodash/isArguments.js",
-      "name": "./node_modules/lodash/isArguments.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isArguments.js",
-      "name": "./node_modules/lodash/isArguments.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isArray": [
-    {
-      "id": "./node_modules/lodash/isArray.js",
-      "name": "./node_modules/lodash/isArray.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isArray.js",
-      "name": "./node_modules/lodash/isArray.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isArrayLike": [
-    {
-      "id": "./node_modules/lodash/isArrayLike.js",
-      "name": "./node_modules/lodash/isArrayLike.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isArrayLike.js",
-      "name": "./node_modules/lodash/isArrayLike.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isBuffer": [
-    {
-      "id": "./node_modules/lodash/isBuffer.js",
-      "name": "./node_modules/lodash/isBuffer.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/isBuffer.js",
-      "name": "./node_modules/lodash/isBuffer.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/debounce.js",
+      "name": "./node_modules/lodash/debounce.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./isFunction": [
@@ -2995,20 +2885,12 @@
       "name": "./node_modules/lodash/isFunction.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isLength": [
-    {
-      "id": "./node_modules/lodash/isLength.js",
-      "name": "./node_modules/lodash/isLength.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/isLength.js",
-      "name": "./node_modules/lodash/isLength.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/isFunction.js",
+      "name": "./node_modules/lodash/isFunction.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./isObject": [
@@ -3023,20 +2905,12 @@
       "name": "./node_modules/lodash/isObject.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isObjectLike": [
-    {
-      "id": "./node_modules/lodash/isObjectLike.js",
-      "name": "./node_modules/lodash/isObjectLike.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/isObjectLike.js",
-      "name": "./node_modules/lodash/isObjectLike.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/isObject.js",
+      "name": "./node_modules/lodash/isObject.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./isSymbol": [
@@ -3051,34 +2925,12 @@
       "name": "./node_modules/lodash/isSymbol.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./isTypedArray": [
-    {
-      "id": "./node_modules/lodash/isTypedArray.js",
-      "name": "./node_modules/lodash/isTypedArray.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/isTypedArray.js",
-      "name": "./node_modules/lodash/isTypedArray.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./keys": [
-    {
-      "id": "./node_modules/lodash/keys.js",
-      "name": "./node_modules/lodash/keys.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./node_modules/lodash/keys.js",
-      "name": "./node_modules/lodash/keys.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/isSymbol.js",
+      "name": "./node_modules/lodash/isSymbol.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./now": [
@@ -3093,20 +2945,12 @@
       "name": "./node_modules/lodash/now.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./stubFalse": [
-    {
-      "id": "./node_modules/lodash/stubFalse.js",
-      "name": "./node_modules/lodash/stubFalse.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/lodash/stubFalse.js",
-      "name": "./node_modules/lodash/stubFalse.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/now.js",
+      "name": "./node_modules/lodash/now.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./toNumber": [
@@ -3121,20 +2965,12 @@
       "name": "./node_modules/lodash/toNumber.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./../../node_modules/node-libs-browser/node_modules/process/browser.js": [
-    {
-      "id": "./node_modules/node-libs-browser/node_modules/process/browser.js",
-      "name": "./node_modules/node-libs-browser/node_modules/process/browser.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/node-libs-browser/node_modules/process/browser.js",
-      "name": "./node_modules/node-libs-browser/node_modules/process/browser.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/lodash/toNumber.js",
+      "name": "./node_modules/lodash/toNumber.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "punycode": [
@@ -3149,6 +2985,12 @@
       "name": "./node_modules/node-libs-browser/node_modules/punycode/punycode.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/punycode/punycode.js",
+      "name": "./node_modules/node-libs-browser/node_modules/punycode/punycode.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "normalize-url": [
@@ -3163,6 +3005,12 @@
       "name": "./node_modules/normalize-url/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/normalize-url/index.js",
+      "name": "./node_modules/normalize-url/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "normalize.css/normalize.css": [
@@ -3177,6 +3025,12 @@
       "name": "./node_modules/normalize.css/normalize.css",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/normalize.css/normalize.css",
+      "name": "./node_modules/normalize.css/normalize.css",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "object-assign": [
@@ -3191,6 +3045,12 @@
       "name": "./node_modules/object-assign/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/object-assign/index.js",
+      "name": "./node_modules/object-assign/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "prepend-http": [
@@ -3205,6 +3065,12 @@
       "name": "./node_modules/prepend-http/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/prepend-http/index.js",
+      "name": "./node_modules/prepend-http/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "prop-types/checkPropTypes": [
@@ -3219,6 +3085,12 @@
       "name": "./node_modules/prop-types/checkPropTypes.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/prop-types/checkPropTypes.js",
+      "name": "./node_modules/prop-types/checkPropTypes.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./factoryWithTypeCheckers": [
@@ -3233,6 +3105,12 @@
       "name": "./node_modules/prop-types/factoryWithTypeCheckers.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/prop-types/factoryWithTypeCheckers.js",
+      "name": "./node_modules/prop-types/factoryWithTypeCheckers.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "prop-types": [
@@ -3247,6 +3125,12 @@
       "name": "./node_modules/prop-types/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/prop-types/index.js",
+      "name": "./node_modules/prop-types/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./lib/ReactPropTypesSecret": [
@@ -3261,6 +3145,12 @@
       "name": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "name": "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "query-string": [
@@ -3275,6 +3165,12 @@
       "name": "./node_modules/query-string/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/query-string/index.js",
+      "name": "./node_modules/query-string/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./decode": [
@@ -3289,6 +3185,12 @@
       "name": "./node_modules/querystring-es3/decode.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/querystring-es3/decode.js",
+      "name": "./node_modules/querystring-es3/decode.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./encode": [
@@ -3303,6 +3205,12 @@
       "name": "./node_modules/querystring-es3/encode.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/querystring-es3/encode.js",
+      "name": "./node_modules/querystring-es3/encode.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "querystring": [
@@ -3317,6 +3225,12 @@
       "name": "./node_modules/querystring-es3/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/querystring-es3/index.js",
+      "name": "./node_modules/querystring-es3/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cjs/react-dom.development.js": [
@@ -3331,6 +3245,12 @@
       "name": "./node_modules/react-dom/cjs/react-dom.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "name": "./node_modules/react-dom/cjs/react-dom.development.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-dom": [
@@ -3345,6 +3265,12 @@
       "name": "./node_modules/react-dom/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-dom/index.js",
+      "name": "./node_modules/react-dom/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-helmet": [
@@ -3359,6 +3285,12 @@
       "name": "./node_modules/react-helmet/lib/Helmet.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-helmet/lib/Helmet.js",
+      "name": "./node_modules/react-helmet/lib/Helmet.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./HelmetConstants.js": [
@@ -3373,6 +3305,12 @@
       "name": "./node_modules/react-helmet/lib/HelmetConstants.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "name": "./node_modules/react-helmet/lib/HelmetConstants.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./HelmetUtils.js": [
@@ -3387,6 +3325,12 @@
       "name": "./node_modules/react-helmet/lib/HelmetUtils.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "name": "./node_modules/react-helmet/lib/HelmetUtils.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./dist/react-hot-loader.development.js": [
@@ -3401,6 +3345,12 @@
       "name": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.development.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./dist/react-hot-loader.production.min.js": [
@@ -3415,6 +3365,12 @@
       "name": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "name": "./node_modules/react-hot-loader/dist/react-hot-loader.production.min.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-hot-loader": [
@@ -3429,6 +3385,12 @@
       "name": "./node_modules/react-hot-loader/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-hot-loader/index.js",
+      "name": "./node_modules/react-hot-loader/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cjs/react-is.development.js": [
@@ -3443,6 +3405,12 @@
       "name": "./node_modules/react-is/cjs/react-is.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-is/cjs/react-is.development.js",
+      "name": "./node_modules/react-is/cjs/react-is.development.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-is": [
@@ -3457,6 +3425,12 @@
       "name": "./node_modules/react-is/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-is/index.js",
+      "name": "./node_modules/react-is/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-lifecycles-compat": [
@@ -3471,6 +3445,12 @@
       "name": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "name": "./node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-loadable": [
@@ -3485,6 +3465,12 @@
       "name": "./node_modules/react-loadable/lib/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-loadable/lib/index.js",
+      "name": "./node_modules/react-loadable/lib/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./components/Context": [
@@ -3499,6 +3485,12 @@
       "name": "./node_modules/react-redux/es/components/Context.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/components/Context.js",
+      "name": "./node_modules/react-redux/es/components/Context.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./components/Provider": [
@@ -3513,6 +3505,12 @@
       "name": "./node_modules/react-redux/es/components/Provider.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/components/Provider.js",
+      "name": "./node_modules/react-redux/es/components/Provider.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./components/connectAdvanced": [
@@ -3527,6 +3525,12 @@
       "name": "./node_modules/react-redux/es/components/connectAdvanced.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/components/connectAdvanced.js",
+      "name": "./node_modules/react-redux/es/components/connectAdvanced.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./connect/connect": [
@@ -3541,6 +3545,12 @@
       "name": "./node_modules/react-redux/es/connect/connect.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/connect/connect.js",
+      "name": "./node_modules/react-redux/es/connect/connect.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./mapDispatchToProps": [
@@ -3555,6 +3565,12 @@
       "name": "./node_modules/react-redux/es/connect/mapDispatchToProps.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/connect/mapDispatchToProps.js",
+      "name": "./node_modules/react-redux/es/connect/mapDispatchToProps.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./mapStateToProps": [
@@ -3569,6 +3585,12 @@
       "name": "./node_modules/react-redux/es/connect/mapStateToProps.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/connect/mapStateToProps.js",
+      "name": "./node_modules/react-redux/es/connect/mapStateToProps.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./mergeProps": [
@@ -3583,6 +3605,12 @@
       "name": "./node_modules/react-redux/es/connect/mergeProps.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/connect/mergeProps.js",
+      "name": "./node_modules/react-redux/es/connect/mergeProps.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./selectorFactory": [
@@ -3597,6 +3625,12 @@
       "name": "./node_modules/react-redux/es/connect/selectorFactory.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/connect/selectorFactory.js",
+      "name": "./node_modules/react-redux/es/connect/selectorFactory.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./verifySubselectors": [
@@ -3611,6 +3645,12 @@
       "name": "./node_modules/react-redux/es/connect/verifySubselectors.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/connect/verifySubselectors.js",
+      "name": "./node_modules/react-redux/es/connect/verifySubselectors.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./wrapMapToProps": [
@@ -3625,6 +3665,12 @@
       "name": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
+      "name": "./node_modules/react-redux/es/connect/wrapMapToProps.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-redux": [
@@ -3639,6 +3685,12 @@
       "name": "./node_modules/react-redux/es/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/index.js",
+      "name": "./node_modules/react-redux/es/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./isPlainObject": [
@@ -3653,6 +3705,12 @@
       "name": "./node_modules/react-redux/es/utils/isPlainObject.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/utils/isPlainObject.js",
+      "name": "./node_modules/react-redux/es/utils/isPlainObject.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "../utils/shallowEqual": [
@@ -3667,6 +3725,12 @@
       "name": "./node_modules/react-redux/es/utils/shallowEqual.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/utils/shallowEqual.js",
+      "name": "./node_modules/react-redux/es/utils/shallowEqual.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "../utils/verifyPlainObject": [
@@ -3681,9 +3745,15 @@
       "name": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
+      "name": "./node_modules/react-redux/es/utils/verifyPlainObject.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
-  "../utils/warning": [
+  "./warning": [
     {
       "id": "./node_modules/react-redux/es/utils/warning.js",
       "name": "./node_modules/react-redux/es/utils/warning.js",
@@ -3695,6 +3765,12 @@
       "name": "./node_modules/react-redux/es/utils/warning.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-redux/es/utils/warning.js",
+      "name": "./node_modules/react-redux/es/utils/warning.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-router-config": [
@@ -3709,6 +3785,12 @@
       "name": "./node_modules/react-router-config/esm/react-router-config.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-router-config/esm/react-router-config.js",
+      "name": "./node_modules/react-router-config/esm/react-router-config.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-router-dom": [
@@ -3723,6 +3805,12 @@
       "name": "./node_modules/react-router-dom/esm/react-router-dom.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-router-dom/esm/react-router-dom.js",
+      "name": "./node_modules/react-router-dom/esm/react-router-dom.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-router": [
@@ -3737,6 +3825,12 @@
       "name": "./node_modules/react-router/esm/react-router.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-router/esm/react-router.js",
+      "name": "./node_modules/react-router/esm/react-router.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "isarray": [
@@ -3751,6 +3845,12 @@
       "name": "./node_modules/react-router/node_modules/isarray/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-router/node_modules/isarray/index.js",
+      "name": "./node_modules/react-router/node_modules/isarray/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "path-to-regexp": [
@@ -3765,6 +3865,12 @@
       "name": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
+      "name": "./node_modules/react-router/node_modules/path-to-regexp/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react-side-effect": [
@@ -3779,6 +3885,12 @@
       "name": "./node_modules/react-side-effect/lib/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react-side-effect/lib/index.js",
+      "name": "./node_modules/react-side-effect/lib/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cjs/react.development.js": [
@@ -3793,6 +3905,12 @@
       "name": "./node_modules/react/cjs/react.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react/cjs/react.development.js",
+      "name": "./node_modules/react/cjs/react.development.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "react": [
@@ -3807,6 +3925,12 @@
       "name": "./node_modules/react/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/react/index.js",
+      "name": "./node_modules/react/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "redux-thunk": [
@@ -3821,6 +3945,12 @@
       "name": "./node_modules/redux-thunk/es/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/redux-thunk/es/index.js",
+      "name": "./node_modules/redux-thunk/es/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "redux": [
@@ -3835,20 +3965,12 @@
       "name": "./node_modules/redux/es/redux.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "regenerator-runtime/runtime": [
-    {
-      "id": "./node_modules/regenerator-runtime/runtime.js",
-      "name": "./node_modules/regenerator-runtime/runtime.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./node_modules/regenerator-runtime/runtime.js",
-      "name": "./node_modules/regenerator-runtime/runtime.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./node_modules/redux/es/redux.js",
+      "name": "./node_modules/redux/es/redux.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "resolve-pathname": [
@@ -3863,6 +3985,12 @@
       "name": "./node_modules/resolve-pathname/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/resolve-pathname/index.js",
+      "name": "./node_modules/resolve-pathname/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cjs/scheduler-tracing.development.js": [
@@ -3877,6 +4005,12 @@
       "name": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
+      "name": "./node_modules/scheduler/cjs/scheduler-tracing.development.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./cjs/scheduler.development.js": [
@@ -3891,6 +4025,12 @@
       "name": "./node_modules/scheduler/cjs/scheduler.development.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/scheduler/cjs/scheduler.development.js",
+      "name": "./node_modules/scheduler/cjs/scheduler.development.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "scheduler": [
@@ -3905,6 +4045,12 @@
       "name": "./node_modules/scheduler/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/scheduler/index.js",
+      "name": "./node_modules/scheduler/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "scheduler/tracing": [
@@ -3919,6 +4065,12 @@
       "name": "./node_modules/scheduler/tracing.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/scheduler/tracing.js",
+      "name": "./node_modules/scheduler/tracing.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "shallowequal": [
@@ -3933,6 +4085,12 @@
       "name": "./node_modules/shallowequal/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/shallowequal/index.js",
+      "name": "./node_modules/shallowequal/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "sort-keys": [
@@ -3947,6 +4105,12 @@
       "name": "./node_modules/sort-keys/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/sort-keys/index.js",
+      "name": "./node_modules/sort-keys/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "strict-uri-encode": [
@@ -3961,6 +4125,12 @@
       "name": "./node_modules/strict-uri-encode/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/strict-uri-encode/index.js",
+      "name": "./node_modules/strict-uri-encode/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "strip-ansi": [
@@ -3975,6 +4145,12 @@
       "name": "./node_modules/strip-ansi/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/strip-ansi/index.js",
+      "name": "./node_modules/strip-ansi/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "symbol-observable": [
@@ -3989,6 +4165,12 @@
       "name": "./node_modules/symbol-observable/es/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/symbol-observable/es/index.js",
+      "name": "./node_modules/symbol-observable/es/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./ponyfill.js": [
@@ -4003,6 +4185,12 @@
       "name": "./node_modules/symbol-observable/es/ponyfill.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/symbol-observable/es/ponyfill.js",
+      "name": "./node_modules/symbol-observable/es/ponyfill.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "tiny-invariant": [
@@ -4017,6 +4205,12 @@
       "name": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
+      "name": "./node_modules/tiny-invariant/dist/tiny-invariant.esm.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "tiny-warning": [
@@ -4031,6 +4225,12 @@
       "name": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
+      "name": "./node_modules/tiny-warning/dist/tiny-warning.esm.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "url": [
@@ -4045,6 +4245,12 @@
       "name": "./node_modules/url/url.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/url/url.js",
+      "name": "./node_modules/url/url.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./util": [
@@ -4059,6 +4265,12 @@
       "name": "./node_modules/url/util.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/url/util.js",
+      "name": "./node_modules/url/util.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "value-equal": [
@@ -4073,6 +4285,12 @@
       "name": "./node_modules/value-equal/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/value-equal/index.js",
+      "name": "./node_modules/value-equal/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "warning": [
@@ -4087,6 +4305,12 @@
       "name": "./node_modules/warning/browser.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/warning/browser.js",
+      "name": "./node_modules/warning/browser.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./client-overlay": [
@@ -4101,6 +4325,12 @@
       "name": "./node_modules/webpack-hot-middleware/client-overlay.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack-hot-middleware/client-overlay.js",
+      "name": "./node_modules/webpack-hot-middleware/client-overlay.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "webpack-hot-middleware/client?reload=true": [
@@ -4115,6 +4345,12 @@
       "name": "./node_modules/webpack-hot-middleware/client.js?reload=true",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack-hot-middleware/client.js?reload=true",
+      "name": "./node_modules/webpack-hot-middleware/client.js?reload=true",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./process-update": [
@@ -4129,6 +4365,12 @@
       "name": "./node_modules/webpack-hot-middleware/process-update.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack-hot-middleware/process-update.js",
+      "name": "./node_modules/webpack-hot-middleware/process-update.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "!!webpack amd define": [
@@ -4143,6 +4385,12 @@
       "name": "./node_modules/webpack/buildin/amd-define.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/amd-define.js",
+      "name": "./node_modules/webpack/buildin/amd-define.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "!!webpack amd options": [
@@ -4157,9 +4405,15 @@
       "name": "./node_modules/webpack/buildin/amd-options.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/amd-options.js",
+      "name": "./node_modules/webpack/buildin/amd-options.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
-  "./../../webpack/buildin/global.js": [
+  "./../webpack/buildin/global.js": [
     {
       "id": "./node_modules/webpack/buildin/global.js",
       "name": "./node_modules/webpack/buildin/global.js",
@@ -4171,6 +4425,12 @@
       "name": "./node_modules/webpack/buildin/global.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/global.js",
+      "name": "./node_modules/webpack/buildin/global.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../node_modules/webpack/buildin/harmony-module.js": [
@@ -4185,6 +4445,12 @@
       "name": "./node_modules/webpack/buildin/harmony-module.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/harmony-module.js",
+      "name": "./node_modules/webpack/buildin/harmony-module.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./../webpack/buildin/module.js": [
@@ -4199,6 +4465,12 @@
       "name": "./node_modules/webpack/buildin/module.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/webpack/buildin/module.js",
+      "name": "./node_modules/webpack/buildin/module.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./user": [
@@ -4213,20 +4485,12 @@
       "name": "./src/actions/user.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./users": [
-    {
-      "id": "./src/actions/users.js",
-      "name": "./src/actions/users.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/actions/users.js",
-      "name": "./src/actions/users.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./src/actions/user.js",
+      "name": "./src/actions/user.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./assets/logo.svg": [
@@ -4241,6 +4505,12 @@
       "name": "./src/app/assets/logo.svg",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/app/assets/logo.svg",
+      "name": "./src/app/assets/logo.svg",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./app": [
@@ -4255,6 +4525,12 @@
       "name": "./src/app/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/app/index.js",
+      "name": "./src/app/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./styles.scss": [
@@ -4265,18 +4541,6 @@
       "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/ErrorDisplay/styles.scss",
-      "name": "./src/components/ErrorDisplay/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/Loading/styles.scss",
-      "name": "./src/components/Loading/styles.scss",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
       "id": "./src/components/UserCard/styles.scss",
       "name": "./src/components/UserCard/styles.scss",
       "file": "main.css",
@@ -4285,6 +4549,18 @@
     {
       "id": "./src/components/UserList/styles.scss",
       "name": "./src/components/UserList/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/ErrorDisplay/styles.scss",
+      "name": "./src/components/ErrorDisplay/styles.scss",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/Loading/styles.scss",
+      "name": "./src/components/Loading/styles.scss",
       "file": "main.css",
       "publicPath": "/assets/main.css"
     },
@@ -4313,18 +4589,6 @@
       "publicPath": "/assets/main.js"
     },
     {
-      "id": "./src/components/ErrorDisplay/styles.scss",
-      "name": "./src/components/ErrorDisplay/styles.scss",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
-      "id": "./src/components/Loading/styles.scss",
-      "name": "./src/components/Loading/styles.scss",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    },
-    {
       "id": "./src/components/UserCard/styles.scss",
       "name": "./src/components/UserCard/styles.scss",
       "file": "main.js",
@@ -4333,6 +4597,18 @@
     {
       "id": "./src/components/UserList/styles.scss",
       "name": "./src/components/UserList/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/ErrorDisplay/styles.scss",
+      "name": "./src/components/ErrorDisplay/styles.scss",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/Loading/styles.scss",
+      "name": "./src/components/Loading/styles.scss",
       "file": "main.js",
       "publicPath": "/assets/main.js"
     },
@@ -4353,6 +4629,54 @@
       "name": "./src/pages/UserInfo/styles.scss",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/app/styles.scss",
+      "name": "./src/app/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/components/UserCard/styles.scss",
+      "name": "./src/components/UserCard/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/components/UserList/styles.scss",
+      "name": "./src/components/UserList/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/components/ErrorDisplay/styles.scss",
+      "name": "./src/components/ErrorDisplay/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/components/Loading/styles.scss",
+      "name": "./src/components/Loading/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/pages/Home/styles.scss",
+      "name": "./src/pages/Home/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/pages/NotFound/styles.scss",
+      "name": "./src/pages/NotFound/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/pages/UserInfo/styles.scss",
+      "name": "./src/pages/UserInfo/styles.scss",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./src/client.js": [
@@ -4367,34 +4691,12 @@
       "name": "./src/client.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./ErrorDisplay": [
-    {
-      "id": "./src/components/ErrorDisplay/index.js",
-      "name": "./src/components/ErrorDisplay/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/ErrorDisplay/index.js",
-      "name": "./src/components/ErrorDisplay/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./Loading": [
-    {
-      "id": "./src/components/Loading/index.js",
-      "name": "./src/components/Loading/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/Loading/index.js",
-      "name": "./src/components/Loading/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./src/client.js",
+      "name": "./src/client.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./UserCard": [
@@ -4409,34 +4711,12 @@
       "name": "./src/components/UserCard/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./UserList": [
-    {
-      "id": "./src/components/UserList/index.js",
-      "name": "./src/components/UserList/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/components/UserList/index.js",
-      "name": "./src/components/UserList/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "../../components": [
-    {
-      "id": "./src/components/index.js",
-      "name": "./src/components/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/components/index.js",
-      "name": "./src/components/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./src/components/UserCard/index.js",
+      "name": "./src/components/UserCard/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./default": [
@@ -4451,6 +4731,12 @@
       "name": "./src/config/default.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/config/default.js",
+      "name": "./src/config/default.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "../config": [
@@ -4465,10 +4751,102 @@
       "name": "./src/config/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/config/index.js",
+      "name": "./src/config/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./home": [
+    {
+      "id": "./src/reducers/home.js",
+      "name": "./src/reducers/home.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/reducers/home.js",
+      "name": "./src/reducers/home.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/reducers/home.js",
+      "name": "./src/reducers/home.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "../reducers": [
+    {
+      "id": "./src/reducers/index.js",
+      "name": "./src/reducers/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/reducers/index.js",
+      "name": "./src/reducers/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/reducers/index.js",
+      "name": "./src/reducers/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./UserList": [
+    {
+      "id": "./src/components/UserList/index.js",
+      "name": "./src/components/UserList/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/UserList/index.js",
+      "name": "./src/components/UserList/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/UserList/index.js",
+      "name": "./src/components/UserList/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "../../components": [
+    {
+      "id": "./src/components/index.js",
+      "name": "./src/components/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/index.js",
+      "name": "./src/components/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/index.js",
+      "name": "./src/components/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./Home": [
     {
+      "id": "./src/pages/Home/index.js",
+      "name": "./src/pages/Home/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
       "id": "./src/pages/Home/Home.js",
       "name": "./src/pages/Home/Home.js",
       "file": "main.css",
@@ -4477,8 +4855,8 @@
     {
       "id": "./src/pages/Home/index.js",
       "name": "./src/pages/Home/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
     },
     {
       "id": "./src/pages/Home/Home.js",
@@ -4489,8 +4867,1634 @@
     {
       "id": "./src/pages/Home/index.js",
       "name": "./src/pages/Home/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    },
+    {
+      "id": "./src/pages/Home/Home.js",
+      "name": "./src/pages/Home/Home.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./pages": [
+    {
+      "id": "./src/pages/index.js",
+      "name": "./src/pages/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/pages/index.js",
+      "name": "./src/pages/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/pages/index.js",
+      "name": "./src/pages/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_advance-string-index": [
+    {
+      "id": "./node_modules/core-js/modules/_advance-string-index.js",
+      "name": "./node_modules/core-js/modules/_advance-string-index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_advance-string-index.js",
+      "name": "./node_modules/core-js/modules/_advance-string-index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_advance-string-index.js",
+      "name": "./node_modules/core-js/modules/_advance-string-index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_fix-re-wks": [
+    {
+      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "name": "./node_modules/core-js/modules/_fix-re-wks.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_flags": [
+    {
+      "id": "./node_modules/core-js/modules/_flags.js",
+      "name": "./node_modules/core-js/modules/_flags.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_flags.js",
+      "name": "./node_modules/core-js/modules/_flags.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_flags.js",
+      "name": "./node_modules/core-js/modules/_flags.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_is-array": [
+    {
+      "id": "./node_modules/core-js/modules/_is-array.js",
+      "name": "./node_modules/core-js/modules/_is-array.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_is-array.js",
+      "name": "./node_modules/core-js/modules/_is-array.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_is-array.js",
+      "name": "./node_modules/core-js/modules/_is-array.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_meta": [
+    {
+      "id": "./node_modules/core-js/modules/_meta.js",
+      "name": "./node_modules/core-js/modules/_meta.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_meta.js",
+      "name": "./node_modules/core-js/modules/_meta.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_meta.js",
+      "name": "./node_modules/core-js/modules/_meta.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_object-gopd": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gopd.js",
+      "name": "./node_modules/core-js/modules/_object-gopd.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopd.js",
+      "name": "./node_modules/core-js/modules/_object-gopd.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopd.js",
+      "name": "./node_modules/core-js/modules/_object-gopd.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_regexp-exec": [
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_wks-ext": [
+    {
+      "id": "./node_modules/core-js/modules/_wks-ext.js",
+      "name": "./node_modules/core-js/modules/_wks-ext.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_wks-ext.js",
+      "name": "./node_modules/core-js/modules/_wks-ext.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_wks-ext.js",
+      "name": "./node_modules/core-js/modules/_wks-ext.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "core-js/modules/es6.regexp.match": [
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.match.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "core-js/modules/es7.symbol.async-iterator": [
+    {
+      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "name": "./node_modules/core-js/modules/es7.symbol.async-iterator.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./ErrorDisplay": [
+    {
+      "id": "./src/components/ErrorDisplay/index.js",
+      "name": "./src/components/ErrorDisplay/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/ErrorDisplay/index.js",
+      "name": "./src/components/ErrorDisplay/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/ErrorDisplay/index.js",
+      "name": "./src/components/ErrorDisplay/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_enum-keys": [
+    {
+      "id": "./node_modules/core-js/modules/_enum-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_enum-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_enum-keys.js",
+      "name": "./node_modules/core-js/modules/_enum-keys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_for-of": [
+    {
+      "id": "./node_modules/core-js/modules/_for-of.js",
+      "name": "./node_modules/core-js/modules/_for-of.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_for-of.js",
+      "name": "./node_modules/core-js/modules/_for-of.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_for-of.js",
+      "name": "./node_modules/core-js/modules/_for-of.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_invoke": [
+    {
+      "id": "./node_modules/core-js/modules/_invoke.js",
+      "name": "./node_modules/core-js/modules/_invoke.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_invoke.js",
+      "name": "./node_modules/core-js/modules/_invoke.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_invoke.js",
+      "name": "./node_modules/core-js/modules/_invoke.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_is-array-iter": [
+    {
+      "id": "./node_modules/core-js/modules/_is-array-iter.js",
+      "name": "./node_modules/core-js/modules/_is-array-iter.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_is-array-iter.js",
+      "name": "./node_modules/core-js/modules/_is-array-iter.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_is-array-iter.js",
+      "name": "./node_modules/core-js/modules/_is-array-iter.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_iter-call": [
+    {
+      "id": "./node_modules/core-js/modules/_iter-call.js",
+      "name": "./node_modules/core-js/modules/_iter-call.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-call.js",
+      "name": "./node_modules/core-js/modules/_iter-call.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-call.js",
+      "name": "./node_modules/core-js/modules/_iter-call.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_iter-detect": [
+    {
+      "id": "./node_modules/core-js/modules/_iter-detect.js",
+      "name": "./node_modules/core-js/modules/_iter-detect.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-detect.js",
+      "name": "./node_modules/core-js/modules/_iter-detect.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_iter-detect.js",
+      "name": "./node_modules/core-js/modules/_iter-detect.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_microtask": [
+    {
+      "id": "./node_modules/core-js/modules/_microtask.js",
+      "name": "./node_modules/core-js/modules/_microtask.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_microtask.js",
+      "name": "./node_modules/core-js/modules/_microtask.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_microtask.js",
+      "name": "./node_modules/core-js/modules/_microtask.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_new-promise-capability": [
+    {
+      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "name": "./node_modules/core-js/modules/_new-promise-capability.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_object-gopn-ext": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "name": "./node_modules/core-js/modules/_object-gopn-ext.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_object-gopn": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn.js",
+      "name": "./node_modules/core-js/modules/_object-gopn.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn.js",
+      "name": "./node_modules/core-js/modules/_object-gopn.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gopn.js",
+      "name": "./node_modules/core-js/modules/_object-gopn.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_object-gops": [
+    {
+      "id": "./node_modules/core-js/modules/_object-gops.js",
+      "name": "./node_modules/core-js/modules/_object-gops.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gops.js",
+      "name": "./node_modules/core-js/modules/_object-gops.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-gops.js",
+      "name": "./node_modules/core-js/modules/_object-gops.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./Loading": [
+    {
+      "id": "./src/components/Loading/index.js",
+      "name": "./src/components/Loading/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/components/Loading/index.js",
+      "name": "./src/components/Loading/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/components/Loading/index.js",
+      "name": "./src/components/Loading/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_object-pie": [
+    {
+      "id": "./node_modules/core-js/modules/_object-pie.js",
+      "name": "./node_modules/core-js/modules/_object-pie.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-pie.js",
+      "name": "./node_modules/core-js/modules/_object-pie.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_object-pie.js",
+      "name": "./node_modules/core-js/modules/_object-pie.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_perform": [
+    {
+      "id": "./node_modules/core-js/modules/_perform.js",
+      "name": "./node_modules/core-js/modules/_perform.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_perform.js",
+      "name": "./node_modules/core-js/modules/_perform.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_perform.js",
+      "name": "./node_modules/core-js/modules/_perform.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_promise-resolve": [
+    {
+      "id": "./node_modules/core-js/modules/_promise-resolve.js",
+      "name": "./node_modules/core-js/modules/_promise-resolve.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_promise-resolve.js",
+      "name": "./node_modules/core-js/modules/_promise-resolve.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_promise-resolve.js",
+      "name": "./node_modules/core-js/modules/_promise-resolve.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_redefine-all": [
+    {
+      "id": "./node_modules/core-js/modules/_redefine-all.js",
+      "name": "./node_modules/core-js/modules/_redefine-all.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_redefine-all.js",
+      "name": "./node_modules/core-js/modules/_redefine-all.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_redefine-all.js",
+      "name": "./node_modules/core-js/modules/_redefine-all.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_regexp-exec-abstract": [
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "name": "./node_modules/core-js/modules/_regexp-exec-abstract.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_set-proto": [
+    {
+      "id": "./node_modules/core-js/modules/_set-proto.js",
+      "name": "./node_modules/core-js/modules/_set-proto.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-proto.js",
+      "name": "./node_modules/core-js/modules/_set-proto.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-proto.js",
+      "name": "./node_modules/core-js/modules/_set-proto.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_set-species": [
+    {
+      "id": "./node_modules/core-js/modules/_set-species.js",
+      "name": "./node_modules/core-js/modules/_set-species.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-species.js",
+      "name": "./node_modules/core-js/modules/_set-species.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_set-species.js",
+      "name": "./node_modules/core-js/modules/_set-species.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_species-constructor": [
+    {
+      "id": "./node_modules/core-js/modules/_species-constructor.js",
+      "name": "./node_modules/core-js/modules/_species-constructor.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_species-constructor.js",
+      "name": "./node_modules/core-js/modules/_species-constructor.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_species-constructor.js",
+      "name": "./node_modules/core-js/modules/_species-constructor.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_string-at": [
+    {
+      "id": "./node_modules/core-js/modules/_string-at.js",
+      "name": "./node_modules/core-js/modules/_string-at.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_string-at.js",
+      "name": "./node_modules/core-js/modules/_string-at.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_string-at.js",
+      "name": "./node_modules/core-js/modules/_string-at.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_task": [
+    {
+      "id": "./node_modules/core-js/modules/_task.js",
+      "name": "./node_modules/core-js/modules/_task.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_task.js",
+      "name": "./node_modules/core-js/modules/_task.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_task.js",
+      "name": "./node_modules/core-js/modules/_task.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_user-agent": [
+    {
+      "id": "./node_modules/core-js/modules/_user-agent.js",
+      "name": "./node_modules/core-js/modules/_user-agent.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_user-agent.js",
+      "name": "./node_modules/core-js/modules/_user-agent.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_user-agent.js",
+      "name": "./node_modules/core-js/modules/_user-agent.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_wks-define": [
+    {
+      "id": "./node_modules/core-js/modules/_wks-define.js",
+      "name": "./node_modules/core-js/modules/_wks-define.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_wks-define.js",
+      "name": "./node_modules/core-js/modules/_wks-define.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/_wks-define.js",
+      "name": "./node_modules/core-js/modules/_wks-define.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./core.get-iterator-method": [
+    {
+      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "name": "./node_modules/core-js/modules/core.get-iterator-method.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "core-js/modules/es6.object.set-prototype-of": [
+    {
+      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "name": "./node_modules/core-js/modules/es6.object.set-prototype-of.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "core-js/modules/es6.promise": [
+    {
+      "id": "./node_modules/core-js/modules/es6.promise.js",
+      "name": "./node_modules/core-js/modules/es6.promise.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.promise.js",
+      "name": "./node_modules/core-js/modules/es6.promise.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.promise.js",
+      "name": "./node_modules/core-js/modules/es6.promise.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./es6.regexp.exec": [
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "name": "./node_modules/core-js/modules/es6.regexp.exec.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "core-js/modules/es6.symbol": [
+    {
+      "id": "./node_modules/core-js/modules/es6.symbol.js",
+      "name": "./node_modules/core-js/modules/es6.symbol.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.symbol.js",
+      "name": "./node_modules/core-js/modules/es6.symbol.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/core-js/modules/es6.symbol.js",
+      "name": "./node_modules/core-js/modules/es6.symbol.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "is-buffer": [
+    {
+      "id": "./node_modules/is-buffer/index.js",
+      "name": "./node_modules/is-buffer/index.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/is-buffer/index.js",
+      "name": "./node_modules/is-buffer/index.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/is-buffer/index.js",
+      "name": "./node_modules/is-buffer/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_apply": [
+    {
+      "id": "./node_modules/lodash/_apply.js",
+      "name": "./node_modules/lodash/_apply.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_apply.js",
+      "name": "./node_modules/lodash/_apply.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_apply.js",
+      "name": "./node_modules/lodash/_apply.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_arrayLikeKeys": [
+    {
+      "id": "./node_modules/lodash/_arrayLikeKeys.js",
+      "name": "./node_modules/lodash/_arrayLikeKeys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_arrayLikeKeys.js",
+      "name": "./node_modules/lodash/_arrayLikeKeys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_arrayLikeKeys.js",
+      "name": "./node_modules/lodash/_arrayLikeKeys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_baseIsArguments": [
+    {
+      "id": "./node_modules/lodash/_baseIsArguments.js",
+      "name": "./node_modules/lodash/_baseIsArguments.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseIsArguments.js",
+      "name": "./node_modules/lodash/_baseIsArguments.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseIsArguments.js",
+      "name": "./node_modules/lodash/_baseIsArguments.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_baseIsTypedArray": [
+    {
+      "id": "./node_modules/lodash/_baseIsTypedArray.js",
+      "name": "./node_modules/lodash/_baseIsTypedArray.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseIsTypedArray.js",
+      "name": "./node_modules/lodash/_baseIsTypedArray.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseIsTypedArray.js",
+      "name": "./node_modules/lodash/_baseIsTypedArray.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_baseKeys": [
+    {
+      "id": "./node_modules/lodash/_baseKeys.js",
+      "name": "./node_modules/lodash/_baseKeys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseKeys.js",
+      "name": "./node_modules/lodash/_baseKeys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseKeys.js",
+      "name": "./node_modules/lodash/_baseKeys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_baseRest": [
+    {
+      "id": "./node_modules/lodash/_baseRest.js",
+      "name": "./node_modules/lodash/_baseRest.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseRest.js",
+      "name": "./node_modules/lodash/_baseRest.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseRest.js",
+      "name": "./node_modules/lodash/_baseRest.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_baseSetToString": [
+    {
+      "id": "./node_modules/lodash/_baseSetToString.js",
+      "name": "./node_modules/lodash/_baseSetToString.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseSetToString.js",
+      "name": "./node_modules/lodash/_baseSetToString.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseSetToString.js",
+      "name": "./node_modules/lodash/_baseSetToString.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_baseTimes": [
+    {
+      "id": "./node_modules/lodash/_baseTimes.js",
+      "name": "./node_modules/lodash/_baseTimes.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseTimes.js",
+      "name": "./node_modules/lodash/_baseTimes.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseTimes.js",
+      "name": "./node_modules/lodash/_baseTimes.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_baseUnary": [
+    {
+      "id": "./node_modules/lodash/_baseUnary.js",
+      "name": "./node_modules/lodash/_baseUnary.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_baseUnary.js",
+      "name": "./node_modules/lodash/_baseUnary.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_baseUnary.js",
+      "name": "./node_modules/lodash/_baseUnary.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_copyObject": [
+    {
+      "id": "./node_modules/lodash/_copyObject.js",
+      "name": "./node_modules/lodash/_copyObject.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_copyObject.js",
+      "name": "./node_modules/lodash/_copyObject.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_copyObject.js",
+      "name": "./node_modules/lodash/_copyObject.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_coreJsData": [
+    {
+      "id": "./node_modules/lodash/_coreJsData.js",
+      "name": "./node_modules/lodash/_coreJsData.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_coreJsData.js",
+      "name": "./node_modules/lodash/_coreJsData.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_coreJsData.js",
+      "name": "./node_modules/lodash/_coreJsData.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_createAssigner": [
+    {
+      "id": "./node_modules/lodash/_createAssigner.js",
+      "name": "./node_modules/lodash/_createAssigner.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_createAssigner.js",
+      "name": "./node_modules/lodash/_createAssigner.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_createAssigner.js",
+      "name": "./node_modules/lodash/_createAssigner.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_getValue": [
+    {
+      "id": "./node_modules/lodash/_getValue.js",
+      "name": "./node_modules/lodash/_getValue.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_getValue.js",
+      "name": "./node_modules/lodash/_getValue.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_getValue.js",
+      "name": "./node_modules/lodash/_getValue.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_isIndex": [
+    {
+      "id": "./node_modules/lodash/_isIndex.js",
+      "name": "./node_modules/lodash/_isIndex.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isIndex.js",
+      "name": "./node_modules/lodash/_isIndex.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_isIndex.js",
+      "name": "./node_modules/lodash/_isIndex.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_isIterateeCall": [
+    {
+      "id": "./node_modules/lodash/_isIterateeCall.js",
+      "name": "./node_modules/lodash/_isIterateeCall.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isIterateeCall.js",
+      "name": "./node_modules/lodash/_isIterateeCall.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_isIterateeCall.js",
+      "name": "./node_modules/lodash/_isIterateeCall.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_isMasked": [
+    {
+      "id": "./node_modules/lodash/_isMasked.js",
+      "name": "./node_modules/lodash/_isMasked.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isMasked.js",
+      "name": "./node_modules/lodash/_isMasked.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_isMasked.js",
+      "name": "./node_modules/lodash/_isMasked.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_isPrototype": [
+    {
+      "id": "./node_modules/lodash/_isPrototype.js",
+      "name": "./node_modules/lodash/_isPrototype.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_isPrototype.js",
+      "name": "./node_modules/lodash/_isPrototype.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_isPrototype.js",
+      "name": "./node_modules/lodash/_isPrototype.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_nativeKeys": [
+    {
+      "id": "./node_modules/lodash/_nativeKeys.js",
+      "name": "./node_modules/lodash/_nativeKeys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_nativeKeys.js",
+      "name": "./node_modules/lodash/_nativeKeys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_nativeKeys.js",
+      "name": "./node_modules/lodash/_nativeKeys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_nodeUtil": [
+    {
+      "id": "./node_modules/lodash/_nodeUtil.js",
+      "name": "./node_modules/lodash/_nodeUtil.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_nodeUtil.js",
+      "name": "./node_modules/lodash/_nodeUtil.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_nodeUtil.js",
+      "name": "./node_modules/lodash/_nodeUtil.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_overArg": [
+    {
+      "id": "./node_modules/lodash/_overArg.js",
+      "name": "./node_modules/lodash/_overArg.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_overArg.js",
+      "name": "./node_modules/lodash/_overArg.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_overArg.js",
+      "name": "./node_modules/lodash/_overArg.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_overRest": [
+    {
+      "id": "./node_modules/lodash/_overRest.js",
+      "name": "./node_modules/lodash/_overRest.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_overRest.js",
+      "name": "./node_modules/lodash/_overRest.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_overRest.js",
+      "name": "./node_modules/lodash/_overRest.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_setToString": [
+    {
+      "id": "./node_modules/lodash/_setToString.js",
+      "name": "./node_modules/lodash/_setToString.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_setToString.js",
+      "name": "./node_modules/lodash/_setToString.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_setToString.js",
+      "name": "./node_modules/lodash/_setToString.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_shortOut": [
+    {
+      "id": "./node_modules/lodash/_shortOut.js",
+      "name": "./node_modules/lodash/_shortOut.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_shortOut.js",
+      "name": "./node_modules/lodash/_shortOut.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_shortOut.js",
+      "name": "./node_modules/lodash/_shortOut.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./_toSource": [
+    {
+      "id": "./node_modules/lodash/_toSource.js",
+      "name": "./node_modules/lodash/_toSource.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/_toSource.js",
+      "name": "./node_modules/lodash/_toSource.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/_toSource.js",
+      "name": "./node_modules/lodash/_toSource.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./constant": [
+    {
+      "id": "./node_modules/lodash/constant.js",
+      "name": "./node_modules/lodash/constant.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/constant.js",
+      "name": "./node_modules/lodash/constant.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/constant.js",
+      "name": "./node_modules/lodash/constant.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./eq": [
+    {
+      "id": "./node_modules/lodash/eq.js",
+      "name": "./node_modules/lodash/eq.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/eq.js",
+      "name": "./node_modules/lodash/eq.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/eq.js",
+      "name": "./node_modules/lodash/eq.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./identity": [
+    {
+      "id": "./node_modules/lodash/identity.js",
+      "name": "./node_modules/lodash/identity.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/identity.js",
+      "name": "./node_modules/lodash/identity.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/identity.js",
+      "name": "./node_modules/lodash/identity.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./isArguments": [
+    {
+      "id": "./node_modules/lodash/isArguments.js",
+      "name": "./node_modules/lodash/isArguments.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isArguments.js",
+      "name": "./node_modules/lodash/isArguments.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/isArguments.js",
+      "name": "./node_modules/lodash/isArguments.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./isArray": [
+    {
+      "id": "./node_modules/lodash/isArray.js",
+      "name": "./node_modules/lodash/isArray.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isArray.js",
+      "name": "./node_modules/lodash/isArray.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/isArray.js",
+      "name": "./node_modules/lodash/isArray.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./isArrayLike": [
+    {
+      "id": "./node_modules/lodash/isArrayLike.js",
+      "name": "./node_modules/lodash/isArrayLike.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isArrayLike.js",
+      "name": "./node_modules/lodash/isArrayLike.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/isArrayLike.js",
+      "name": "./node_modules/lodash/isArrayLike.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./isBuffer": [
+    {
+      "id": "./node_modules/lodash/isBuffer.js",
+      "name": "./node_modules/lodash/isBuffer.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isBuffer.js",
+      "name": "./node_modules/lodash/isBuffer.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/isBuffer.js",
+      "name": "./node_modules/lodash/isBuffer.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./isLength": [
+    {
+      "id": "./node_modules/lodash/isLength.js",
+      "name": "./node_modules/lodash/isLength.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isLength.js",
+      "name": "./node_modules/lodash/isLength.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/isLength.js",
+      "name": "./node_modules/lodash/isLength.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./isObjectLike": [
+    {
+      "id": "./node_modules/lodash/isObjectLike.js",
+      "name": "./node_modules/lodash/isObjectLike.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isObjectLike.js",
+      "name": "./node_modules/lodash/isObjectLike.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/isObjectLike.js",
+      "name": "./node_modules/lodash/isObjectLike.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./isTypedArray": [
+    {
+      "id": "./node_modules/lodash/isTypedArray.js",
+      "name": "./node_modules/lodash/isTypedArray.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/isTypedArray.js",
+      "name": "./node_modules/lodash/isTypedArray.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/isTypedArray.js",
+      "name": "./node_modules/lodash/isTypedArray.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./keys": [
+    {
+      "id": "./node_modules/lodash/keys.js",
+      "name": "./node_modules/lodash/keys.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/keys.js",
+      "name": "./node_modules/lodash/keys.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/keys.js",
+      "name": "./node_modules/lodash/keys.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./stubFalse": [
+    {
+      "id": "./node_modules/lodash/stubFalse.js",
+      "name": "./node_modules/lodash/stubFalse.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/lodash/stubFalse.js",
+      "name": "./node_modules/lodash/stubFalse.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/lodash/stubFalse.js",
+      "name": "./node_modules/lodash/stubFalse.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./../../node_modules/node-libs-browser/node_modules/process/browser.js": [
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "name": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "name": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "name": "./node_modules/node-libs-browser/node_modules/process/browser.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "regenerator-runtime/runtime": [
+    {
+      "id": "./node_modules/regenerator-runtime/runtime.js",
+      "name": "./node_modules/regenerator-runtime/runtime.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./node_modules/regenerator-runtime/runtime.js",
+      "name": "./node_modules/regenerator-runtime/runtime.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./node_modules/regenerator-runtime/runtime.js",
+      "name": "./node_modules/regenerator-runtime/runtime.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
+    }
+  ],
+  "./users": [
+    {
+      "id": "./src/actions/users.js",
+      "name": "./src/actions/users.js",
+      "file": "main.css",
+      "publicPath": "/assets/main.css"
+    },
+    {
+      "id": "./src/actions/users.js",
+      "name": "./src/actions/users.js",
+      "file": "main.js",
+      "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/actions/users.js",
+      "name": "./src/actions/users.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./NotFound": [
@@ -4505,6 +6509,12 @@
       "name": "./src/pages/NotFound/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/pages/NotFound/index.js",
+      "name": "./src/pages/NotFound/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./UserInfo": [
@@ -4531,48 +6541,18 @@
       "name": "./src/pages/UserInfo/index.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
-    }
-  ],
-  "./pages": [
-    {
-      "id": "./src/pages/index.js",
-      "name": "./src/pages/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
     },
     {
-      "id": "./src/pages/index.js",
-      "name": "./src/pages/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "./home": [
-    {
-      "id": "./src/reducers/home.js",
-      "name": "./src/reducers/home.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
+      "id": "./src/pages/UserInfo/UserInfo.js",
+      "name": "./src/pages/UserInfo/UserInfo.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     },
     {
-      "id": "./src/reducers/home.js",
-      "name": "./src/reducers/home.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
-    }
-  ],
-  "../reducers": [
-    {
-      "id": "./src/reducers/index.js",
-      "name": "./src/reducers/index.js",
-      "file": "main.css",
-      "publicPath": "/assets/main.css"
-    },
-    {
-      "id": "./src/reducers/index.js",
-      "name": "./src/reducers/index.js",
-      "file": "main.js",
-      "publicPath": "/assets/main.js"
+      "id": "./src/pages/UserInfo/index.js",
+      "name": "./src/pages/UserInfo/index.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./userInfo": [
@@ -4587,6 +6567,12 @@
       "name": "./src/reducers/userInfo.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/reducers/userInfo.js",
+      "name": "./src/reducers/userInfo.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./routes": [
@@ -4601,6 +6587,12 @@
       "name": "./src/routes.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/routes.js",
+      "name": "./src/routes.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ],
   "./utils/configureStore": [
@@ -4615,6 +6607,12 @@
       "name": "./src/utils/configureStore.js",
       "file": "main.js",
       "publicPath": "/assets/main.js"
+    },
+    {
+      "id": "./src/utils/configureStore.js",
+      "name": "./src/utils/configureStore.js",
+      "file": "main.5842c65ed68e63caec94.hot-update.js",
+      "publicPath": "/assets/main.5842c65ed68e63caec94.hot-update.js"
     }
   ]
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render, hydrate } from 'react-dom';
 import { createBrowserHistory } from 'history';
 import { AppContainer } from 'react-hot-loader';
 import { Provider } from 'react-redux';
@@ -18,8 +18,8 @@ const history = createBrowserHistory();
 const initialState = window.__INITIAL_STATE__;
 const store = configureStore(history, initialState);
 
-const render = (Routes: Array<Object>, History: Object, Store: Object) => {
-  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate;
+const renderApp = (Routes: Array<Object>, History: Object, Store: Object) => {
+  const renderMethod = module.hot ? render : hydrate;
   renderMethod(
     <AppContainer>
       <Provider store={Store}>
@@ -34,7 +34,7 @@ const render = (Routes: Array<Object>, History: Object, Store: Object) => {
 };
 
 // react-loadable setup
-Loadable.preloadReady().then(() => render(routes, history, store));
+Loadable.preloadReady().then(() => renderApp(routes, history, store));
 
 if (module.hot) {
   // Enable webpack hot module replacement for routes

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import { render, hydrate } from 'react-dom';
+import ReactDOM from 'react-dom';
 import { createBrowserHistory } from 'history';
 import { AppContainer } from 'react-hot-loader';
 import { Provider } from 'react-redux';
@@ -18,8 +18,8 @@ const history = createBrowserHistory();
 const initialState = window.__INITIAL_STATE__;
 const store = configureStore(history, initialState);
 
-const renderApp = (Routes: Array<Object>, History: Object, Store: Object) => {
-  const renderMethod = module.hot ? render : hydrate;
+const render = (Routes: Array<Object>, History: Object, Store: Object) => {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate;
   renderMethod(
     <AppContainer>
       <Provider store={Store}>
@@ -34,7 +34,7 @@ const renderApp = (Routes: Array<Object>, History: Object, Store: Object) => {
 };
 
 // react-loadable setup
-Loadable.preloadReady().then(() => renderApp(routes, history, store));
+Loadable.preloadReady().then(() => render(routes, history, store));
 
 if (module.hot) {
   // Enable webpack hot module replacement for routes

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import { hydrate } from 'react-dom';
+import ReactDOM from 'react-dom';
 import { createBrowserHistory } from 'history';
 import { AppContainer } from 'react-hot-loader';
 import { Provider } from 'react-redux';
@@ -18,11 +18,12 @@ const history = createBrowserHistory();
 const initialState = window.__INITIAL_STATE__;
 const store = configureStore(history, initialState);
 
-const render = (Routes: Array<Object>) => {
-  hydrate(
+const render = (Routes: Array<Object>, History: Object, Store: Object) => {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate;
+  renderMethod(
     <AppContainer>
-      <Provider store={store}>
-        <ConnectedRouter history={history}>
+      <Provider store={Store}>
+        <ConnectedRouter history={History}>
           <BrowserRouter>{renderRoutes(Routes)}</BrowserRouter>
         </ConnectedRouter>
       </Provider>
@@ -33,7 +34,7 @@ const render = (Routes: Array<Object>) => {
 };
 
 // react-loadable setup
-Loadable.preloadReady().then(() => render(routes));
+Loadable.preloadReady().then(() => render(routes, history, store));
 
 if (module.hot) {
   // Enable webpack hot module replacement for routes
@@ -41,7 +42,7 @@ if (module.hot) {
     try {
       const nextRoutes = require('./routes').default;
 
-      render(nextRoutes);
+      render(nextRoutes, history, store);
     } catch (error) {
       console.error(`==> 😭  Routes hot reloading error ${error}`);
     }


### PR DESCRIPTION
Fixes the issues regarding #210.

- When the module is hot, the client should use `ReactDOM.render` instead of `ReactDOM.hydrate`. Otherwise, there will be a disconnect between the client-side HTML and the server-side HTML upon refresh.
- In addition, you'll need to pass `history` and `store` to the `render` function in `./src/client.js` since the two are intertwined in `connected-react-router` they should stay consistent across hot updates; otherwise,  you'll get a `Warning: You cannot change <Router history>.`

