### PR TITLE
Set public static path on both dev and prod

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -32,12 +32,10 @@ app.use(compression());
 // Use for http request debug (show errors only)
 app.use(logger('dev', { skip: (req, res) => res.statusCode < 400 }));
 app.use(favicon(path.resolve(process.cwd(), 'public/favicon.ico')));
+app.use(express.static(path.resolve(process.cwd(), 'public')));
 
-if (!__DEV__) {
-  app.use(express.static(path.resolve(process.cwd(), 'public')));
-} else {
+if (__DEV__) {
   /* Run express as webpack dev server */
-
   const webpack = require('webpack');
   const webpackConfig = require('../tools/webpack/config.babel');
   const compiler = webpack(webpackConfig);


### PR DESCRIPTION
Setting path for static files in the public folder so files such as manifest.json are accessible on development mode.