### PR TITLE
omit sourceMap in production

### DIFF
--- a/tools/webpack/config.babel.js
+++ b/tools/webpack/config.babel.js
@@ -103,12 +103,12 @@ const getStyleLoaders = (sass = false) => {
           localIdentName: isDev ? "[name]__[local]" : "[hash:base64:5]",
           context: path.resolve(process.cwd(), "src"),
         },
-        sourceMap: true,
+        sourceMap: isDev,
       },
     },
-    { loader: "postcss", options: { sourceMap: true } },
+    { loader: "postcss", options: { sourceMap: isDev } },
   ];
-  if (sass) loaders.push({ loader: "sass", options: { sourceMap: true } });
+  if (sass) loaders.push({ loader: "sass", options: { sourceMap: isDev } });
 
   return loaders;
 };


### PR DESCRIPTION
Due to issue #247 and rejected PR #248 you said you would omit source map in production build by adding some configuration. but I still don't see the configuration. maybe I'm wrong but I decided to add this config to webpage config. So this PR after accepting will resolve issue #247 
